### PR TITLE
feat(datadog): upgrade dd-agent schema to v1.5.0

### DIFF
--- a/datadoghq.com/datadogagent_v1alpha1.json
+++ b/datadoghq.com/datadogagent_v1alpha1.json
@@ -1,49 +1,66 @@
 {
+  "description": "DatadogAgent Deployment with Datadog Operator.",
   "properties": {
     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
+      "description": "DatadogAgentSpec defines the desired state of DatadogAgent.",
       "properties": {
         "agent": {
+          "description": "The desired state of the Agent as an extended daemonset. Contains the Node Agent configuration and deployment strategy.",
           "properties": {
             "additionalAnnotations": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "AdditionalAnnotations provide annotations that will be added to the Agent Pods.",
               "type": "object"
             },
             "additionalLabels": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "AdditionalLabels provide labels that will be added to the Agent Pods.",
               "type": "object"
             },
             "affinity": {
+              "description": "If specified, the pod's scheduling constraints.",
               "properties": {
                 "nodeAffinity": {
+                  "description": "Describes node affinity scheduling rules for the pod.",
                   "properties": {
                     "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
                       "items": {
+                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
                         "properties": {
                           "preference": {
+                            "description": "A node selector term, associated with the corresponding weight.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -60,15 +77,20 @@
                                 "type": "array"
                               },
                               "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -89,6 +111,7 @@
                             "additionalProperties": false
                           },
                           "weight": {
+                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -103,20 +126,28 @@
                       "type": "array"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
                       "properties": {
                         "nodeSelectorTerms": {
+                          "description": "Required. A list of node selector terms. The terms are ORed.",
                           "items": {
+                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -133,15 +164,20 @@
                                 "type": "array"
                               },
                               "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -175,24 +211,34 @@
                   "additionalProperties": false
                 },
                 "podAffinity": {
+                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
                   "properties": {
                     "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
                       "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
                         "properties": {
                           "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
                             "properties": {
                               "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -212,6 +258,7 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
@@ -219,17 +266,23 @@
                                 "additionalProperties": false
                               },
                               "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -249,6 +302,7 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
@@ -256,12 +310,14 @@
                                 "additionalProperties": false
                               },
                               "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                                 "items": {
                                   "type": "string"
                                 },
                                 "type": "array"
                               },
                               "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                 "type": "string"
                               }
                             },
@@ -272,6 +328,7 @@
                             "additionalProperties": false
                           },
                           "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -286,20 +343,28 @@
                       "type": "array"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
                       "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
                         "properties": {
                           "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -319,6 +384,7 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
@@ -326,17 +392,23 @@
                             "additionalProperties": false
                           },
                           "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -356,6 +428,7 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
@@ -363,12 +436,14 @@
                             "additionalProperties": false
                           },
                           "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                             "type": "string"
                           }
                         },
@@ -385,24 +460,34 @@
                   "additionalProperties": false
                 },
                 "podAntiAffinity": {
+                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
                   "properties": {
                     "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
                       "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
                         "properties": {
                           "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
                             "properties": {
                               "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -422,6 +507,7 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
@@ -429,17 +515,23 @@
                                 "additionalProperties": false
                               },
                               "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -459,6 +551,7 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
@@ -466,12 +559,14 @@
                                 "additionalProperties": false
                               },
                               "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                                 "items": {
                                   "type": "string"
                                 },
                                 "type": "array"
                               },
                               "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                 "type": "string"
                               }
                             },
@@ -482,6 +577,7 @@
                             "additionalProperties": false
                           },
                           "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -496,20 +592,28 @@
                       "type": "array"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
                       "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
                         "properties": {
                           "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -529,6 +633,7 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
@@ -536,17 +641,23 @@
                             "additionalProperties": false
                           },
                           "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -566,6 +677,7 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
@@ -573,12 +685,14 @@
                             "additionalProperties": false
                           },
                           "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                             "type": "string"
                           }
                         },
@@ -599,8 +713,10 @@
               "additionalProperties": false
             },
             "apm": {
+              "description": "Trace Agent configuration",
               "properties": {
                 "args": {
+                  "description": "Args allows the specification of extra args to `Command` parameter",
                   "items": {
                     "type": "string"
                   },
@@ -608,6 +724,7 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "command": {
+                  "description": "Command allows the specification of custom entrypoint for Trace Agent container",
                   "items": {
                     "type": "string"
                   },
@@ -615,28 +732,38 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "enabled": {
+                  "description": "Enable this to enable APM and tracing, on port 8126. See also: https://github.com/DataDog/docker-dd-agent#tracing-from-the-host",
                   "type": "boolean"
                 },
                 "env": {
+                  "description": "The Datadog Agent supports many environment variables. See also: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables",
                   "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
                     "properties": {
                       "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                         "type": "string"
                       },
                       "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
                         "type": "string"
                       },
                       "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                         "properties": {
                           "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
                             "properties": {
                               "key": {
+                                "description": "The key to select.",
                                 "type": "string"
                               },
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -647,11 +774,14 @@
                             "additionalProperties": false
                           },
                           "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                             "properties": {
                               "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                 "type": "string"
                               },
                               "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
                                 "type": "string"
                               }
                             },
@@ -662,8 +792,10 @@
                             "additionalProperties": false
                           },
                           "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                             "properties": {
                               "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
                                 "type": "string"
                               },
                               "divisor": {
@@ -675,10 +807,12 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                 "x-kubernetes-int-or-string": true
                               },
                               "resource": {
+                                "description": "Required: resource to select",
                                 "type": "string"
                               }
                             },
@@ -689,14 +823,18 @@
                             "additionalProperties": false
                           },
                           "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
                             "properties": {
                               "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -724,14 +862,18 @@
                   "x-kubernetes-list-type": "map"
                 },
                 "hostPort": {
+                  "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
                   "format": "int32",
                   "type": "integer"
                 },
                 "livenessProbe": {
+                  "description": "Configure the Liveness Probe of the APM container",
                   "properties": {
                     "exec": {
+                      "description": "Exec specifies the action to take.",
                       "properties": {
                         "command": {
+                          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                           "items": {
                             "type": "string"
                           },
@@ -742,16 +884,20 @@
                       "additionalProperties": false
                     },
                     "failureThreshold": {
+                      "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "grpc": {
+                      "description": "GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.",
                       "properties": {
                         "port": {
+                          "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "service": {
+                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
                           "type": "string"
                         }
                       },
@@ -762,17 +908,23 @@
                       "additionalProperties": false
                     },
                     "httpGet": {
+                      "description": "HTTPGet specifies the http request to perform.",
                       "properties": {
                         "host": {
+                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
                           "type": "string"
                         },
                         "httpHeaders": {
+                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                           "items": {
+                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                             "properties": {
                               "name": {
+                                "description": "The header field name",
                                 "type": "string"
                               },
                               "value": {
+                                "description": "The header field value",
                                 "type": "string"
                               }
                             },
@@ -786,6 +938,7 @@
                           "type": "array"
                         },
                         "path": {
+                          "description": "Path to access on the HTTP server.",
                           "type": "string"
                         },
                         "port": {
@@ -797,9 +950,11 @@
                               "type": "string"
                             }
                           ],
+                          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
                           "x-kubernetes-int-or-string": true
                         },
                         "scheme": {
+                          "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
                           "type": "string"
                         }
                       },
@@ -810,20 +965,25 @@
                       "additionalProperties": false
                     },
                     "initialDelaySeconds": {
+                      "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                       "format": "int32",
                       "type": "integer"
                     },
                     "periodSeconds": {
+                      "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "successThreshold": {
+                      "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "tcpSocket": {
+                      "description": "TCPSocket specifies an action involving a TCP port.",
                       "properties": {
                         "host": {
+                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
                           "type": "string"
                         },
                         "port": {
@@ -835,6 +995,7 @@
                               "type": "string"
                             }
                           ],
+                          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
                           "x-kubernetes-int-or-string": true
                         }
                       },
@@ -845,10 +1006,12 @@
                       "additionalProperties": false
                     },
                     "terminationGracePeriodSeconds": {
+                      "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "timeoutSeconds": {
+                      "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                       "format": "int32",
                       "type": "integer"
                     }
@@ -857,6 +1020,7 @@
                   "additionalProperties": false
                 },
                 "resources": {
+                  "description": "Datadog APM Agent resource requests and limits. Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class. See also: http://kubernetes.io/docs/user-guide/compute-resources/",
                   "properties": {
                     "limits": {
                       "additionalProperties": {
@@ -871,6 +1035,7 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
+                      "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                       "type": "object"
                     },
                     "requests": {
@@ -886,6 +1051,7 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
+                      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                       "type": "object"
                     }
                   },
@@ -893,11 +1059,14 @@
                   "additionalProperties": false
                 },
                 "unixDomainSocket": {
+                  "description": "UnixDomainSocket socket configuration. See also: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables",
                   "properties": {
                     "enabled": {
+                      "description": "Enable APM over Unix Domain Socket See also: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables",
                       "type": "boolean"
                     },
                     "hostFilepath": {
+                      "description": "Define the host APM socket filepath used when APM over Unix Domain Socket is enabled. (default value: /var/run/datadog/apm.sock) See also: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables",
                       "type": "string"
                     }
                   },
@@ -905,24 +1074,32 @@
                   "additionalProperties": false
                 },
                 "volumeMounts": {
+                  "description": "Specify additional volume mounts in the APM Agent container.",
                   "items": {
+                    "description": "VolumeMount describes a mounting of a Volume within a container.",
                     "properties": {
                       "mountPath": {
+                        "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
                         "type": "string"
                       },
                       "mountPropagation": {
+                        "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
                         "type": "string"
                       },
                       "name": {
+                        "description": "This must match the Name of a Volume.",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
                         "type": "boolean"
                       },
                       "subPath": {
+                        "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
                         "type": "string"
                       },
                       "subPathExpr": {
+                        "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
                         "type": "string"
                       }
                     },
@@ -945,8 +1122,10 @@
               "additionalProperties": false
             },
             "config": {
+              "description": "Agent configuration.",
               "properties": {
                 "args": {
+                  "description": "Args allows the specification of extra args to `Command` parameter",
                   "items": {
                     "type": "string"
                   },
@@ -954,21 +1133,28 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "checksd": {
+                  "description": "Checksd configuration allowing to specify custom checks placed under /etc/datadog-agent/checks.d/ See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.",
                   "properties": {
                     "configMapName": {
+                      "description": "ConfigMapName name of a ConfigMap used to mount a directory.",
                       "type": "string"
                     },
                     "items": {
+                      "description": "items mapping between configMap data key and file path mount.",
                       "items": {
+                        "description": "Maps a string key to a path within a volume.",
                         "properties": {
                           "key": {
+                            "description": "key is the key to project.",
                             "type": "string"
                           },
                           "mode": {
+                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "path": {
+                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                             "type": "string"
                           }
                         },
@@ -990,9 +1176,11 @@
                   "additionalProperties": false
                 },
                 "collectEvents": {
+                  "description": "Enables this to start event collection from the Kubernetes API. See also: https://docs.datadoghq.com/agent/kubernetes/event_collection/",
                   "type": "boolean"
                 },
                 "command": {
+                  "description": "Command allows the specification of custom entrypoint for the Agent container",
                   "items": {
                     "type": "string"
                   },
@@ -1000,21 +1188,28 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "confd": {
+                  "description": "Confd configuration allowing to specify config files for custom checks placed under /etc/datadog-agent/conf.d/. See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.",
                   "properties": {
                     "configMapName": {
+                      "description": "ConfigMapName name of a ConfigMap used to mount a directory.",
                       "type": "string"
                     },
                     "items": {
+                      "description": "items mapping between configMap data key and file path mount.",
                       "items": {
+                        "description": "Maps a string key to a path within a volume.",
                         "properties": {
                           "key": {
+                            "description": "key is the key to project.",
                             "type": "string"
                           },
                           "mode": {
+                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "path": {
+                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                             "type": "string"
                           }
                         },
@@ -1036,11 +1231,14 @@
                   "additionalProperties": false
                 },
                 "criSocket": {
+                  "description": "Configure the CRI Socket.",
                   "properties": {
                     "criSocketPath": {
+                      "description": "Path to the container runtime socket (if different from Docker). This is supported starting from agent 6.6.0.",
                       "type": "string"
                     },
                     "dockerSocketPath": {
+                      "description": "Path to the docker runtime socket.",
                       "type": "string"
                     }
                   },
@@ -1048,24 +1246,32 @@
                   "additionalProperties": false
                 },
                 "ddUrl": {
+                  "description": "The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL. Overrides the site setting defined in \"site\".",
                   "type": "string"
                 },
                 "dogstatsd": {
+                  "description": "Configure Dogstatsd.",
                   "properties": {
                     "dogstatsdOriginDetection": {
+                      "description": "Enable origin detection for container tagging. See also: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging",
                       "type": "boolean"
                     },
                     "mapperProfiles": {
+                      "description": "Configure the Dogstasd Mapper Profiles. Can be passed as raw data or via a json encoded string in a config map. See also: https://docs.datadoghq.com/developers/dogstatsd/dogstatsd_mapper/",
                       "properties": {
                         "configData": {
+                          "description": "ConfigData corresponds to the configuration file content.",
                           "type": "string"
                         },
                         "configMap": {
+                          "description": "Enable to specify a reference to an already existing ConfigMap.",
                           "properties": {
                             "fileKey": {
+                              "description": "FileKey corresponds to the key used in the ConfigMap.Data to store the configuration file content.",
                               "type": "string"
                             },
                             "name": {
+                              "description": "The name of source ConfigMap.",
                               "type": "string"
                             }
                           },
@@ -1077,11 +1283,14 @@
                       "additionalProperties": false
                     },
                     "unixDomainSocket": {
+                      "description": "Configure the Dogstatsd Unix Domain Socket. See also: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/",
                       "properties": {
                         "enabled": {
+                          "description": "Enable APM over Unix Domain Socket. See also: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/",
                           "type": "boolean"
                         },
                         "hostFilepath": {
+                          "description": "Define the host APM socket filepath used when APM over Unix Domain Socket is enabled. (default value: /var/run/datadog/statsd.sock). See also: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/",
                           "type": "string"
                         }
                       },
@@ -1093,25 +1302,34 @@
                   "additionalProperties": false
                 },
                 "env": {
+                  "description": "The Datadog Agent supports many environment variables. See also: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables",
                   "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
                     "properties": {
                       "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                         "type": "string"
                       },
                       "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
                         "type": "string"
                       },
                       "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                         "properties": {
                           "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
                             "properties": {
                               "key": {
+                                "description": "The key to select.",
                                 "type": "string"
                               },
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -1122,11 +1340,14 @@
                             "additionalProperties": false
                           },
                           "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                             "properties": {
                               "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                 "type": "string"
                               },
                               "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
                                 "type": "string"
                               }
                             },
@@ -1137,8 +1358,10 @@
                             "additionalProperties": false
                           },
                           "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                             "properties": {
                               "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
                                 "type": "string"
                               },
                               "divisor": {
@@ -1150,10 +1373,12 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                 "x-kubernetes-int-or-string": true
                               },
                               "resource": {
+                                "description": "Required: resource to select",
                                 "type": "string"
                               }
                             },
@@ -1164,14 +1389,18 @@
                             "additionalProperties": false
                           },
                           "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
                             "properties": {
                               "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -1199,29 +1428,38 @@
                   "x-kubernetes-list-type": "map"
                 },
                 "healthPort": {
+                  "description": "HealthPort of the Agent container for internal liveness probe. Must be the same as the Liveness/Readiness probes.",
                   "format": "int32",
                   "type": "integer"
                 },
                 "hostPort": {
+                  "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
                   "format": "int32",
                   "type": "integer"
                 },
                 "kubelet": {
+                  "description": "KubeletConfig contains the Kubelet configuration parameters",
                   "properties": {
                     "agentCAPath": {
+                      "description": "AgentCAPath is the container path where the kubelet CA certificate is stored. Default: '/var/run/host-kubelet-ca.crt' if hostCAPath is set, else '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'",
                       "type": "string"
                     },
                     "host": {
+                      "description": "Host overrides the host used to contact kubelet API (default to status.hostIP).",
                       "properties": {
                         "configMapKeyRef": {
+                          "description": "Selects a key of a ConfigMap.",
                           "properties": {
                             "key": {
+                              "description": "The key to select.",
                               "type": "string"
                             },
                             "name": {
+                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                               "type": "string"
                             },
                             "optional": {
+                              "description": "Specify whether the ConfigMap or its key must be defined",
                               "type": "boolean"
                             }
                           },
@@ -1232,11 +1470,14 @@
                           "additionalProperties": false
                         },
                         "fieldRef": {
+                          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                           "properties": {
                             "apiVersion": {
+                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                               "type": "string"
                             },
                             "fieldPath": {
+                              "description": "Path of the field to select in the specified API version.",
                               "type": "string"
                             }
                           },
@@ -1247,8 +1488,10 @@
                           "additionalProperties": false
                         },
                         "resourceFieldRef": {
+                          "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                           "properties": {
                             "containerName": {
+                              "description": "Container name: required for volumes, optional for env vars",
                               "type": "string"
                             },
                             "divisor": {
@@ -1260,10 +1503,12 @@
                                   "type": "string"
                                 }
                               ],
+                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                               "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                               "x-kubernetes-int-or-string": true
                             },
                             "resource": {
+                              "description": "Required: resource to select",
                               "type": "string"
                             }
                           },
@@ -1274,14 +1519,18 @@
                           "additionalProperties": false
                         },
                         "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
                           "properties": {
                             "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
                               "type": "string"
                             },
                             "name": {
+                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                               "type": "string"
                             },
                             "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
                               "type": "boolean"
                             }
                           },
@@ -1296,9 +1545,11 @@
                       "additionalProperties": false
                     },
                     "hostCAPath": {
+                      "description": "HostCAPath is the host path where the kubelet CA certificate is stored.",
                       "type": "string"
                     },
                     "tlsVerify": {
+                      "description": "TLSVerify toggles kubelet TLS verification. Default: true",
                       "type": "boolean"
                     }
                   },
@@ -1306,13 +1557,17 @@
                   "additionalProperties": false
                 },
                 "leaderElection": {
+                  "description": "Enables leader election mechanism for event collection.",
                   "type": "boolean"
                 },
                 "livenessProbe": {
+                  "description": "Configure the Liveness Probe of the Agent container",
                   "properties": {
                     "exec": {
+                      "description": "Exec specifies the action to take.",
                       "properties": {
                         "command": {
+                          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                           "items": {
                             "type": "string"
                           },
@@ -1323,16 +1578,20 @@
                       "additionalProperties": false
                     },
                     "failureThreshold": {
+                      "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "grpc": {
+                      "description": "GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.",
                       "properties": {
                         "port": {
+                          "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "service": {
+                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
                           "type": "string"
                         }
                       },
@@ -1343,17 +1602,23 @@
                       "additionalProperties": false
                     },
                     "httpGet": {
+                      "description": "HTTPGet specifies the http request to perform.",
                       "properties": {
                         "host": {
+                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
                           "type": "string"
                         },
                         "httpHeaders": {
+                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                           "items": {
+                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                             "properties": {
                               "name": {
+                                "description": "The header field name",
                                 "type": "string"
                               },
                               "value": {
+                                "description": "The header field value",
                                 "type": "string"
                               }
                             },
@@ -1367,6 +1632,7 @@
                           "type": "array"
                         },
                         "path": {
+                          "description": "Path to access on the HTTP server.",
                           "type": "string"
                         },
                         "port": {
@@ -1378,9 +1644,11 @@
                               "type": "string"
                             }
                           ],
+                          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
                           "x-kubernetes-int-or-string": true
                         },
                         "scheme": {
+                          "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
                           "type": "string"
                         }
                       },
@@ -1391,20 +1659,25 @@
                       "additionalProperties": false
                     },
                     "initialDelaySeconds": {
+                      "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                       "format": "int32",
                       "type": "integer"
                     },
                     "periodSeconds": {
+                      "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "successThreshold": {
+                      "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "tcpSocket": {
+                      "description": "TCPSocket specifies an action involving a TCP port.",
                       "properties": {
                         "host": {
+                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
                           "type": "string"
                         },
                         "port": {
@@ -1416,6 +1689,7 @@
                               "type": "string"
                             }
                           ],
+                          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
                           "x-kubernetes-int-or-string": true
                         }
                       },
@@ -1426,10 +1700,12 @@
                       "additionalProperties": false
                     },
                     "terminationGracePeriodSeconds": {
+                      "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "timeoutSeconds": {
+                      "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                       "format": "int32",
                       "type": "integer"
                     }
@@ -1438,37 +1714,45 @@
                   "additionalProperties": false
                 },
                 "logLevel": {
+                  "description": "Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off",
                   "type": "string"
                 },
                 "namespaceLabelsAsTags": {
                   "additionalProperties": {
                     "type": "string"
                   },
+                  "description": "Provide a mapping of Kubernetes Namespace Labels to Datadog Tags. <KUBERNETES_LABEL>: <DATADOG_TAG_KEY>",
                   "type": "object"
                 },
                 "nodeLabelsAsTags": {
                   "additionalProperties": {
                     "type": "string"
                   },
+                  "description": "Provide a mapping of Kubernetes Node Labels to Datadog Tags. <KUBERNETES_LABEL>: <DATADOG_TAG_KEY>",
                   "type": "object"
                 },
                 "podAnnotationsAsTags": {
                   "additionalProperties": {
                     "type": "string"
                   },
+                  "description": "Provide a mapping of Kubernetes Pod Annotations to Datadog Tags. <KUBERNETES_ANNOTATIONS>: <DATADOG_TAG_KEY>",
                   "type": "object"
                 },
                 "podLabelsAsTags": {
                   "additionalProperties": {
                     "type": "string"
                   },
+                  "description": "Provide a mapping of Kubernetes Pod Labels to Datadog Tags. <KUBERNETES_LABEL>: <DATADOG_TAG_KEY>",
                   "type": "object"
                 },
                 "readinessProbe": {
+                  "description": "Configure the Readiness Probe of the Agent container",
                   "properties": {
                     "exec": {
+                      "description": "Exec specifies the action to take.",
                       "properties": {
                         "command": {
+                          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                           "items": {
                             "type": "string"
                           },
@@ -1479,16 +1763,20 @@
                       "additionalProperties": false
                     },
                     "failureThreshold": {
+                      "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "grpc": {
+                      "description": "GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.",
                       "properties": {
                         "port": {
+                          "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "service": {
+                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
                           "type": "string"
                         }
                       },
@@ -1499,17 +1787,23 @@
                       "additionalProperties": false
                     },
                     "httpGet": {
+                      "description": "HTTPGet specifies the http request to perform.",
                       "properties": {
                         "host": {
+                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
                           "type": "string"
                         },
                         "httpHeaders": {
+                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                           "items": {
+                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                             "properties": {
                               "name": {
+                                "description": "The header field name",
                                 "type": "string"
                               },
                               "value": {
+                                "description": "The header field value",
                                 "type": "string"
                               }
                             },
@@ -1523,6 +1817,7 @@
                           "type": "array"
                         },
                         "path": {
+                          "description": "Path to access on the HTTP server.",
                           "type": "string"
                         },
                         "port": {
@@ -1534,9 +1829,11 @@
                               "type": "string"
                             }
                           ],
+                          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
                           "x-kubernetes-int-or-string": true
                         },
                         "scheme": {
+                          "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
                           "type": "string"
                         }
                       },
@@ -1547,20 +1844,25 @@
                       "additionalProperties": false
                     },
                     "initialDelaySeconds": {
+                      "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                       "format": "int32",
                       "type": "integer"
                     },
                     "periodSeconds": {
+                      "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "successThreshold": {
+                      "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "tcpSocket": {
+                      "description": "TCPSocket specifies an action involving a TCP port.",
                       "properties": {
                         "host": {
+                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
                           "type": "string"
                         },
                         "port": {
@@ -1572,6 +1874,7 @@
                               "type": "string"
                             }
                           ],
+                          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
                           "x-kubernetes-int-or-string": true
                         }
                       },
@@ -1582,10 +1885,12 @@
                       "additionalProperties": false
                     },
                     "terminationGracePeriodSeconds": {
+                      "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "timeoutSeconds": {
+                      "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                       "format": "int32",
                       "type": "integer"
                     }
@@ -1594,6 +1899,7 @@
                   "additionalProperties": false
                 },
                 "resources": {
+                  "description": "Datadog Agent resource requests and limits. Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class. See also: http://kubernetes.io/docs/user-guide/compute-resources/",
                   "properties": {
                     "limits": {
                       "additionalProperties": {
@@ -1608,6 +1914,7 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
+                      "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                       "type": "object"
                     },
                     "requests": {
@@ -1623,6 +1930,7 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
+                      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                       "type": "object"
                     }
                   },
@@ -1630,37 +1938,48 @@
                   "additionalProperties": false
                 },
                 "securityContext": {
+                  "description": "Pod-level SecurityContext.",
                   "properties": {
                     "fsGroup": {
+                      "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "fsGroupChangePolicy": {
+                      "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.",
                       "type": "string"
                     },
                     "runAsGroup": {
+                      "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "runAsNonRoot": {
+                      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
                       "type": "boolean"
                     },
                     "runAsUser": {
+                      "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "seLinuxOptions": {
+                      "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
                       "properties": {
                         "level": {
+                          "description": "Level is SELinux level label that applies to the container.",
                           "type": "string"
                         },
                         "role": {
+                          "description": "Role is a SELinux role label that applies to the container.",
                           "type": "string"
                         },
                         "type": {
+                          "description": "Type is a SELinux type label that applies to the container.",
                           "type": "string"
                         },
                         "user": {
+                          "description": "User is a SELinux user label that applies to the container.",
                           "type": "string"
                         }
                       },
@@ -1668,11 +1987,14 @@
                       "additionalProperties": false
                     },
                     "seccompProfile": {
+                      "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.",
                       "properties": {
                         "localhostProfile": {
+                          "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
                           "type": "string"
                         },
                         "type": {
+                          "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
                           "type": "string"
                         }
                       },
@@ -1683,6 +2005,7 @@
                       "additionalProperties": false
                     },
                     "supplementalGroups": {
+                      "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container. Note that this field cannot be set when spec.os.name is windows.",
                       "items": {
                         "format": "int64",
                         "type": "integer"
@@ -1690,12 +2013,16 @@
                       "type": "array"
                     },
                     "sysctls": {
+                      "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
                       "items": {
+                        "description": "Sysctl defines a kernel parameter to be set",
                         "properties": {
                           "name": {
+                            "description": "Name of a property to set",
                             "type": "string"
                           },
                           "value": {
+                            "description": "Value of a property to set",
                             "type": "string"
                           }
                         },
@@ -1709,17 +2036,22 @@
                       "type": "array"
                     },
                     "windowsOptions": {
+                      "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
                       "properties": {
                         "gmsaCredentialSpec": {
+                          "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
                           "type": "string"
                         },
                         "gmsaCredentialSpecName": {
+                          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                           "type": "string"
                         },
                         "hostProcess": {
+                          "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
                           "type": "boolean"
                         },
                         "runAsUserName": {
+                          "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
                           "type": "string"
                         }
                       },
@@ -1731,6 +2063,7 @@
                   "additionalProperties": false
                 },
                 "tags": {
+                  "description": "List of tags to attach to every metric, event and service check collected by this Agent. Learn more about tagging: https://docs.datadoghq.com/tagging/",
                   "items": {
                     "type": "string"
                   },
@@ -1738,22 +2071,29 @@
                   "x-kubernetes-list-type": "set"
                 },
                 "tolerations": {
+                  "description": "If specified, the Agent pod's tolerations.",
                   "items": {
+                    "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
                     "properties": {
                       "effect": {
+                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                         "type": "string"
                       },
                       "key": {
+                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                         "type": "string"
                       },
                       "operator": {
+                        "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
                         "type": "string"
                       },
                       "tolerationSeconds": {
+                        "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
                         "format": "int64",
                         "type": "integer"
                       },
                       "value": {
+                        "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
                         "type": "string"
                       }
                     },
@@ -1764,24 +2104,32 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "volumeMounts": {
+                  "description": "Specify additional volume mounts in the Datadog Agent container.",
                   "items": {
+                    "description": "VolumeMount describes a mounting of a Volume within a container.",
                     "properties": {
                       "mountPath": {
+                        "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
                         "type": "string"
                       },
                       "mountPropagation": {
+                        "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
                         "type": "string"
                       },
                       "name": {
+                        "description": "This must match the Name of a Volume.",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
                         "type": "boolean"
                       },
                       "subPath": {
+                        "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
                         "type": "string"
                       },
                       "subPathExpr": {
+                        "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
                         "type": "string"
                       }
                     },
@@ -1800,21 +2148,28 @@
                   "x-kubernetes-list-type": "map"
                 },
                 "volumes": {
+                  "description": "Specify additional volumes in the Datadog Agent container.",
                   "items": {
+                    "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
                     "properties": {
                       "awsElasticBlockStore": {
+                        "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine",
                             "type": "string"
                           },
                           "partition": {
+                            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
                             "format": "int32",
                             "type": "integer"
                           },
                           "readOnly": {
+                            "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                             "type": "boolean"
                           },
                           "volumeID": {
+                            "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                             "type": "string"
                           }
                         },
@@ -1825,23 +2180,30 @@
                         "additionalProperties": false
                       },
                       "azureDisk": {
+                        "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
                         "properties": {
                           "cachingMode": {
+                            "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
                             "type": "string"
                           },
                           "diskName": {
+                            "description": "diskName is the Name of the data disk in the blob storage",
                             "type": "string"
                           },
                           "diskURI": {
+                            "description": "diskURI is the URI of data disk in the blob storage",
                             "type": "string"
                           },
                           "fsType": {
+                            "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                             "type": "string"
                           },
                           "kind": {
+                            "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           }
                         },
@@ -1853,14 +2215,18 @@
                         "additionalProperties": false
                       },
                       "azureFile": {
+                        "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.",
                         "properties": {
                           "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "secretName": {
+                            "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
                             "type": "string"
                           },
                           "shareName": {
+                            "description": "shareName is the azure share Name",
                             "type": "string"
                           }
                         },
@@ -1872,25 +2238,32 @@
                         "additionalProperties": false
                       },
                       "cephfs": {
+                        "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
                         "properties": {
                           "monitors": {
+                            "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "path": {
+                            "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                             "type": "boolean"
                           },
                           "secretFile": {
+                            "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                             "type": "string"
                           },
                           "secretRef": {
+                            "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -1898,6 +2271,7 @@
                             "additionalProperties": false
                           },
                           "user": {
+                            "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                             "type": "string"
                           }
                         },
@@ -1908,16 +2282,21 @@
                         "additionalProperties": false
                       },
                       "cinder": {
+                        "description": "cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -1925,6 +2304,7 @@
                             "additionalProperties": false
                           },
                           "volumeID": {
+                            "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                             "type": "string"
                           }
                         },
@@ -1935,22 +2315,29 @@
                         "additionalProperties": false
                       },
                       "configMap": {
+                        "description": "configMap represents a configMap that should populate this volume",
                         "properties": {
                           "defaultMode": {
+                            "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                             "items": {
+                              "description": "Maps a string key to a path within a volume.",
                               "properties": {
                                 "key": {
+                                  "description": "key is the key to project.",
                                   "type": "string"
                                 },
                                 "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                   "format": "int32",
                                   "type": "integer"
                                 },
                                 "path": {
+                                  "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                   "type": "string"
                                 }
                               },
@@ -1964,9 +2351,11 @@
                             "type": "array"
                           },
                           "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                             "type": "string"
                           },
                           "optional": {
+                            "description": "optional specify whether the ConfigMap or its keys must be defined",
                             "type": "boolean"
                           }
                         },
@@ -1974,16 +2363,21 @@
                         "additionalProperties": false
                       },
                       "csi": {
+                        "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
                         "properties": {
                           "driver": {
+                            "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
                             "type": "string"
                           },
                           "fsType": {
+                            "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
                             "type": "string"
                           },
                           "nodePublishSecretRef": {
+                            "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -1991,12 +2385,14 @@
                             "additionalProperties": false
                           },
                           "readOnly": {
+                            "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
                             "type": "boolean"
                           },
                           "volumeAttributes": {
                             "additionalProperties": {
                               "type": "string"
                             },
+                            "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
                             "type": "object"
                           }
                         },
@@ -2007,20 +2403,27 @@
                         "additionalProperties": false
                       },
                       "downwardAPI": {
+                        "description": "downwardAPI represents downward API about the pod that should populate this volume",
                         "properties": {
                           "defaultMode": {
+                            "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "items": {
+                            "description": "Items is a list of downward API volume file",
                             "items": {
+                              "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
                               "properties": {
                                 "fieldRef": {
+                                  "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
                                   "properties": {
                                     "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                       "type": "string"
                                     },
                                     "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
                                       "type": "string"
                                     }
                                   },
@@ -2031,15 +2434,19 @@
                                   "additionalProperties": false
                                 },
                                 "mode": {
+                                  "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                   "format": "int32",
                                   "type": "integer"
                                 },
                                 "path": {
+                                  "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
                                   "type": "string"
                                 },
                                 "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
                                   "properties": {
                                     "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
                                       "type": "string"
                                     },
                                     "divisor": {
@@ -2051,10 +2458,12 @@
                                           "type": "string"
                                         }
                                       ],
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                       "x-kubernetes-int-or-string": true
                                     },
                                     "resource": {
+                                      "description": "Required: resource to select",
                                       "type": "string"
                                     }
                                   },
@@ -2078,8 +2487,10 @@
                         "additionalProperties": false
                       },
                       "emptyDir": {
+                        "description": "emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                         "properties": {
                           "medium": {
+                            "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                             "type": "string"
                           },
                           "sizeLimit": {
@@ -2091,6 +2502,7 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           }
@@ -2099,29 +2511,38 @@
                         "additionalProperties": false
                       },
                       "ephemeral": {
+                        "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
                         "properties": {
                           "volumeClaimTemplate": {
+                            "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil.",
                             "properties": {
                               "metadata": {
+                                "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
                                 "type": "object"
                               },
                               "spec": {
+                                "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
                                 "properties": {
                                   "accessModes": {
+                                    "description": "accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
                                     "items": {
                                       "type": "string"
                                     },
                                     "type": "array"
                                   },
                                   "dataSource": {
+                                    "description": "dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.",
                                     "properties": {
                                       "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
                                         "type": "string"
                                       },
                                       "kind": {
+                                        "description": "Kind is the type of resource being referenced",
                                         "type": "string"
                                       },
                                       "name": {
+                                        "description": "Name is the name of resource being referenced",
                                         "type": "string"
                                       }
                                     },
@@ -2133,14 +2554,18 @@
                                     "additionalProperties": false
                                   },
                                   "dataSourceRef": {
+                                    "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.",
                                     "properties": {
                                       "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
                                         "type": "string"
                                       },
                                       "kind": {
+                                        "description": "Kind is the type of resource being referenced",
                                         "type": "string"
                                       },
                                       "name": {
+                                        "description": "Name is the name of resource being referenced",
                                         "type": "string"
                                       }
                                     },
@@ -2152,6 +2577,7 @@
                                     "additionalProperties": false
                                   },
                                   "resources": {
+                                    "description": "resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
                                     "properties": {
                                       "limits": {
                                         "additionalProperties": {
@@ -2166,6 +2592,7 @@
                                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                           "x-kubernetes-int-or-string": true
                                         },
+                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                                         "type": "object"
                                       },
                                       "requests": {
@@ -2181,6 +2608,7 @@
                                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                           "x-kubernetes-int-or-string": true
                                         },
+                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                                         "type": "object"
                                       }
                                     },
@@ -2188,17 +2616,23 @@
                                     "additionalProperties": false
                                   },
                                   "selector": {
+                                    "description": "selector is a label query over volumes to consider for binding.",
                                     "properties": {
                                       "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                         "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                           "properties": {
                                             "key": {
+                                              "description": "key is the label key that the selector applies to.",
                                               "type": "string"
                                             },
                                             "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                               "type": "string"
                                             },
                                             "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                               "items": {
                                                 "type": "string"
                                               },
@@ -2218,6 +2652,7 @@
                                         "additionalProperties": {
                                           "type": "string"
                                         },
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                         "type": "object"
                                       }
                                     },
@@ -2225,12 +2660,15 @@
                                     "additionalProperties": false
                                   },
                                   "storageClassName": {
+                                    "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
                                     "type": "string"
                                   },
                                   "volumeMode": {
+                                    "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
                                     "type": "string"
                                   },
                                   "volumeName": {
+                                    "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
                                     "type": "string"
                                   }
                                 },
@@ -2249,24 +2687,30 @@
                         "additionalProperties": false
                       },
                       "fc": {
+                        "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine",
                             "type": "string"
                           },
                           "lun": {
+                            "description": "lun is Optional: FC target lun number",
                             "format": "int32",
                             "type": "integer"
                           },
                           "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "targetWWNs": {
+                            "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "wwids": {
+                            "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
                             "items": {
                               "type": "string"
                             },
@@ -2277,25 +2721,32 @@
                         "additionalProperties": false
                       },
                       "flexVolume": {
+                        "description": "flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
                         "properties": {
                           "driver": {
+                            "description": "driver is the name of the driver to use for this volume.",
                             "type": "string"
                           },
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
                             "type": "string"
                           },
                           "options": {
                             "additionalProperties": {
                               "type": "string"
                             },
+                            "description": "options is Optional: this field holds extra command options if any.",
                             "type": "object"
                           },
                           "readOnly": {
+                            "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -2310,11 +2761,14 @@
                         "additionalProperties": false
                       },
                       "flocker": {
+                        "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
                         "properties": {
                           "datasetName": {
+                            "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
                             "type": "string"
                           },
                           "datasetUUID": {
+                            "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
                             "type": "string"
                           }
                         },
@@ -2322,18 +2776,23 @@
                         "additionalProperties": false
                       },
                       "gcePersistentDisk": {
+                        "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine",
                             "type": "string"
                           },
                           "partition": {
+                            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                             "format": "int32",
                             "type": "integer"
                           },
                           "pdName": {
+                            "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                             "type": "boolean"
                           }
                         },
@@ -2344,14 +2803,18 @@
                         "additionalProperties": false
                       },
                       "gitRepo": {
+                        "description": "gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
                         "properties": {
                           "directory": {
+                            "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
                             "type": "string"
                           },
                           "repository": {
+                            "description": "repository is the URL",
                             "type": "string"
                           },
                           "revision": {
+                            "description": "revision is the commit hash for the specified revision.",
                             "type": "string"
                           }
                         },
@@ -2362,14 +2825,18 @@
                         "additionalProperties": false
                       },
                       "glusterfs": {
+                        "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md",
                         "properties": {
                           "endpoints": {
+                            "description": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                             "type": "string"
                           },
                           "path": {
+                            "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                             "type": "boolean"
                           }
                         },
@@ -2381,11 +2848,14 @@
                         "additionalProperties": false
                       },
                       "hostPath": {
+                        "description": "hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
                         "properties": {
                           "path": {
+                            "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                             "type": "string"
                           },
                           "type": {
+                            "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                             "type": "string"
                           }
                         },
@@ -2396,41 +2866,53 @@
                         "additionalProperties": false
                       },
                       "iscsi": {
+                        "description": "iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
                         "properties": {
                           "chapAuthDiscovery": {
+                            "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
                             "type": "boolean"
                           },
                           "chapAuthSession": {
+                            "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
                             "type": "boolean"
                           },
                           "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine",
                             "type": "string"
                           },
                           "initiatorName": {
+                            "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
                             "type": "string"
                           },
                           "iqn": {
+                            "description": "iqn is the target iSCSI Qualified Name.",
                             "type": "string"
                           },
                           "iscsiInterface": {
+                            "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
                             "type": "string"
                           },
                           "lun": {
+                            "description": "lun represents iSCSI Target Lun number.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "portals": {
+                            "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -2438,6 +2920,7 @@
                             "additionalProperties": false
                           },
                           "targetPortal": {
+                            "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
                             "type": "string"
                           }
                         },
@@ -2450,17 +2933,22 @@
                         "additionalProperties": false
                       },
                       "name": {
+                        "description": "name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "nfs": {
+                        "description": "nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                         "properties": {
                           "path": {
+                            "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                             "type": "boolean"
                           },
                           "server": {
+                            "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                             "type": "string"
                           }
                         },
@@ -2472,11 +2960,14 @@
                         "additionalProperties": false
                       },
                       "persistentVolumeClaim": {
+                        "description": "persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                         "properties": {
                           "claimName": {
+                            "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly Will force the ReadOnly setting in VolumeMounts. Default false.",
                             "type": "boolean"
                           }
                         },
@@ -2487,11 +2978,14 @@
                         "additionalProperties": false
                       },
                       "photonPersistentDisk": {
+                        "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                             "type": "string"
                           },
                           "pdID": {
+                            "description": "pdID is the ID that identifies Photon Controller persistent disk",
                             "type": "string"
                           }
                         },
@@ -2502,14 +2996,18 @@
                         "additionalProperties": false
                       },
                       "portworxVolume": {
+                        "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine",
                         "properties": {
                           "fsType": {
+                            "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "volumeID": {
+                            "description": "volumeID uniquely identifies a Portworx volume",
                             "type": "string"
                           }
                         },
@@ -2520,27 +3018,37 @@
                         "additionalProperties": false
                       },
                       "projected": {
+                        "description": "projected items for all in one resources secrets, configmaps, and downward API",
                         "properties": {
                           "defaultMode": {
+                            "description": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "sources": {
+                            "description": "sources is the list of volume projections",
                             "items": {
+                              "description": "Projection that may be projected along with other supported volume types",
                               "properties": {
                                 "configMap": {
+                                  "description": "configMap information about the configMap data to project",
                                   "properties": {
                                     "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                                       "items": {
+                                        "description": "Maps a string key to a path within a volume.",
                                         "properties": {
                                           "key": {
+                                            "description": "key is the key to project.",
                                             "type": "string"
                                           },
                                           "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                             "format": "int32",
                                             "type": "integer"
                                           },
                                           "path": {
+                                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                             "type": "string"
                                           }
                                         },
@@ -2554,9 +3062,11 @@
                                       "type": "array"
                                     },
                                     "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     },
                                     "optional": {
+                                      "description": "optional specify whether the ConfigMap or its keys must be defined",
                                       "type": "boolean"
                                     }
                                   },
@@ -2564,16 +3074,22 @@
                                   "additionalProperties": false
                                 },
                                 "downwardAPI": {
+                                  "description": "downwardAPI information about the downwardAPI data to project",
                                   "properties": {
                                     "items": {
+                                      "description": "Items is a list of DownwardAPIVolume file",
                                       "items": {
+                                        "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
                                         "properties": {
                                           "fieldRef": {
+                                            "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
                                             "properties": {
                                               "apiVersion": {
+                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                                 "type": "string"
                                               },
                                               "fieldPath": {
+                                                "description": "Path of the field to select in the specified API version.",
                                                 "type": "string"
                                               }
                                             },
@@ -2584,15 +3100,19 @@
                                             "additionalProperties": false
                                           },
                                           "mode": {
+                                            "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                             "format": "int32",
                                             "type": "integer"
                                           },
                                           "path": {
+                                            "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
                                             "type": "string"
                                           },
                                           "resourceFieldRef": {
+                                            "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
                                             "properties": {
                                               "containerName": {
+                                                "description": "Container name: required for volumes, optional for env vars",
                                                 "type": "string"
                                               },
                                               "divisor": {
@@ -2604,10 +3124,12 @@
                                                     "type": "string"
                                                   }
                                                 ],
+                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                                 "x-kubernetes-int-or-string": true
                                               },
                                               "resource": {
+                                                "description": "Required: resource to select",
                                                 "type": "string"
                                               }
                                             },
@@ -2631,18 +3153,24 @@
                                   "additionalProperties": false
                                 },
                                 "secret": {
+                                  "description": "secret information about the secret data to project",
                                   "properties": {
                                     "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                                       "items": {
+                                        "description": "Maps a string key to a path within a volume.",
                                         "properties": {
                                           "key": {
+                                            "description": "key is the key to project.",
                                             "type": "string"
                                           },
                                           "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                             "format": "int32",
                                             "type": "integer"
                                           },
                                           "path": {
+                                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                             "type": "string"
                                           }
                                         },
@@ -2656,9 +3184,11 @@
                                       "type": "array"
                                     },
                                     "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     },
                                     "optional": {
+                                      "description": "optional field specify whether the Secret or its key must be defined",
                                       "type": "boolean"
                                     }
                                   },
@@ -2666,15 +3196,19 @@
                                   "additionalProperties": false
                                 },
                                 "serviceAccountToken": {
+                                  "description": "serviceAccountToken is information about the serviceAccountToken data to project",
                                   "properties": {
                                     "audience": {
+                                      "description": "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
                                       "type": "string"
                                     },
                                     "expirationSeconds": {
+                                      "description": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
                                       "format": "int64",
                                       "type": "integer"
                                     },
                                     "path": {
+                                      "description": "path is the path relative to the mount point of the file to project the token into.",
                                       "type": "string"
                                     }
                                   },
@@ -2695,23 +3229,30 @@
                         "additionalProperties": false
                       },
                       "quobyte": {
+                        "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
                         "properties": {
                           "group": {
+                            "description": "group to map volume access to Default is no group",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
                             "type": "boolean"
                           },
                           "registry": {
+                            "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
                             "type": "string"
                           },
                           "tenant": {
+                            "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
                             "type": "string"
                           },
                           "user": {
+                            "description": "user to map volume access to Defaults to serivceaccount user",
                             "type": "string"
                           },
                           "volume": {
+                            "description": "volume is a string that references an already created Quobyte volume by name.",
                             "type": "string"
                           }
                         },
@@ -2723,31 +3264,40 @@
                         "additionalProperties": false
                       },
                       "rbd": {
+                        "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine",
                             "type": "string"
                           },
                           "image": {
+                            "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "type": "string"
                           },
                           "keyring": {
+                            "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "type": "string"
                           },
                           "monitors": {
+                            "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "pool": {
+                            "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -2755,6 +3305,7 @@
                             "additionalProperties": false
                           },
                           "user": {
+                            "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "type": "string"
                           }
                         },
@@ -2766,22 +3317,29 @@
                         "additionalProperties": false
                       },
                       "scaleIO": {
+                        "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
                             "type": "string"
                           },
                           "gateway": {
+                            "description": "gateway is the host address of the ScaleIO API Gateway.",
                             "type": "string"
                           },
                           "protectionDomain": {
+                            "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -2789,18 +3347,23 @@
                             "additionalProperties": false
                           },
                           "sslEnabled": {
+                            "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
                             "type": "boolean"
                           },
                           "storageMode": {
+                            "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
                             "type": "string"
                           },
                           "storagePool": {
+                            "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
                             "type": "string"
                           },
                           "system": {
+                            "description": "system is the name of the storage system as configured in ScaleIO.",
                             "type": "string"
                           },
                           "volumeName": {
+                            "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
                             "type": "string"
                           }
                         },
@@ -2813,22 +3376,29 @@
                         "additionalProperties": false
                       },
                       "secret": {
+                        "description": "secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
                         "properties": {
                           "defaultMode": {
+                            "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "items": {
+                            "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                             "items": {
+                              "description": "Maps a string key to a path within a volume.",
                               "properties": {
                                 "key": {
+                                  "description": "key is the key to project.",
                                   "type": "string"
                                 },
                                 "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                   "format": "int32",
                                   "type": "integer"
                                 },
                                 "path": {
+                                  "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                   "type": "string"
                                 }
                               },
@@ -2842,9 +3412,11 @@
                             "type": "array"
                           },
                           "optional": {
+                            "description": "optional field specify whether the Secret or its keys must be defined",
                             "type": "boolean"
                           },
                           "secretName": {
+                            "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
                             "type": "string"
                           }
                         },
@@ -2852,16 +3424,21 @@
                         "additionalProperties": false
                       },
                       "storageos": {
+                        "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -2869,9 +3446,11 @@
                             "additionalProperties": false
                           },
                           "volumeName": {
+                            "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
                             "type": "string"
                           },
                           "volumeNamespace": {
+                            "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
                             "type": "string"
                           }
                         },
@@ -2879,17 +3458,22 @@
                         "additionalProperties": false
                       },
                       "vsphereVolume": {
+                        "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                             "type": "string"
                           },
                           "storagePolicyID": {
+                            "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
                             "type": "string"
                           },
                           "storagePolicyName": {
+                            "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
                             "type": "string"
                           },
                           "volumePath": {
+                            "description": "volumePath is the path that identifies vSphere volume vmdk",
                             "type": "string"
                           }
                         },
@@ -2917,16 +3501,21 @@
               "additionalProperties": false
             },
             "customConfig": {
+              "description": "Allow to put custom configuration for the agent, corresponding to the datadog.yaml config file. See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.",
               "properties": {
                 "configData": {
+                  "description": "ConfigData corresponds to the configuration file content.",
                   "type": "string"
                 },
                 "configMap": {
+                  "description": "Enable to specify a reference to an already existing ConfigMap.",
                   "properties": {
                     "fileKey": {
+                      "description": "FileKey corresponds to the key used in the ConfigMap.Data to store the configuration file content.",
                       "type": "string"
                     },
                     "name": {
+                      "description": "The name of source ConfigMap.",
                       "type": "string"
                     }
                   },
@@ -2938,25 +3527,33 @@
               "additionalProperties": false
             },
             "daemonsetName": {
+              "description": "Name of the Daemonset to create or migrate from.",
               "type": "string"
             },
             "deploymentStrategy": {
+              "description": "Update strategy configuration for the DaemonSet.",
               "properties": {
                 "canary": {
+                  "description": "Configure the canary deployment configuration using ExtendedDaemonSet.",
                   "properties": {
                     "autoFail": {
+                      "description": "ExtendedDaemonSetSpecStrategyCanaryAutoFail defines the canary deployment AutoFail parameters of the ExtendedDaemonSet.",
                       "properties": {
                         "canaryTimeout": {
+                          "description": "CanaryTimeout defines the maximum duration of a Canary, after which the Canary deployment is autofailed. This is a safeguard against lengthy Canary pauses. There is no default value.",
                           "type": "string"
                         },
                         "enabled": {
+                          "description": "Enabled enables AutoFail. Default value is true.",
                           "type": "boolean"
                         },
                         "maxRestarts": {
+                          "description": "MaxRestarts defines the number of tolerable (per pod) Canary pod restarts after which the Canary deployment is autofailed. Default value is 5.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "maxRestartsDuration": {
+                          "description": "MaxRestartsDuration defines the maximum duration of tolerable Canary pod restarts after which the Canary deployment is autofailed. There is no default value.",
                           "type": "string"
                         }
                       },
@@ -2964,15 +3561,19 @@
                       "additionalProperties": false
                     },
                     "autoPause": {
+                      "description": "ExtendedDaemonSetSpecStrategyCanaryAutoPause defines the canary deployment AutoPause parameters of the ExtendedDaemonSet.",
                       "properties": {
                         "enabled": {
+                          "description": "Enabled enables AutoPause. Default value is true.",
                           "type": "boolean"
                         },
                         "maxRestarts": {
+                          "description": "MaxRestarts defines the number of tolerable (per pod) Canary pod restarts after which the Canary deployment is autopaused. Default value is 2.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "maxSlowStartDuration": {
+                          "description": "MaxSlowStartDuration defines the maximum slow start duration for a pod (stuck in Creating state) after which the Canary deployment is autopaused. There is no default value.",
                           "type": "string"
                         }
                       },
@@ -2983,6 +3584,7 @@
                       "type": "string"
                     },
                     "noRestartsDuration": {
+                      "description": "NoRestartsDuration defines min duration since last restart to end the canary phase.",
                       "type": "string"
                     },
                     "nodeAntiAffinityKeys": {
@@ -2993,17 +3595,23 @@
                       "x-kubernetes-list-type": "set"
                     },
                     "nodeSelector": {
+                      "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
                       "properties": {
                         "matchExpressions": {
+                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                           "items": {
+                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                             "properties": {
                               "key": {
+                                "description": "key is the label key that the selector applies to.",
                                 "type": "string"
                               },
                               "operator": {
+                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                 "type": "string"
                               },
                               "values": {
+                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                 "items": {
                                   "type": "string"
                                 },
@@ -3023,6 +3631,7 @@
                           "additionalProperties": {
                             "type": "string"
                           },
+                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                           "type": "object"
                         }
                       },
@@ -3041,6 +3650,7 @@
                       "x-kubernetes-int-or-string": true
                     },
                     "validationMode": {
+                      "description": "ValidationMode used to configure how a canary deployment is validated. Possible values are 'auto' (default) and 'manual'",
                       "enum": [
                         "auto",
                         "manual"
@@ -3052,11 +3662,14 @@
                   "additionalProperties": false
                 },
                 "reconcileFrequency": {
+                  "description": "The reconcile frequency of the ExtendDaemonSet.",
                   "type": "string"
                 },
                 "rollingUpdate": {
+                  "description": "Configure the rolling updater strategy of the DaemonSet or the ExtendedDaemonSet.",
                   "properties": {
                     "maxParallelPodCreation": {
+                      "description": "The maximum number of pods created in parallel. Default value is 250.",
                       "format": "int32",
                       "type": "integer"
                     },
@@ -3069,6 +3682,7 @@
                           "type": "string"
                         }
                       ],
+                      "description": "MaxPodSchedulerFailure the maximum number of not scheduled on its Node due to a scheduler failure: resource constraints. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute",
                       "x-kubernetes-int-or-string": true
                     },
                     "maxUnavailable": {
@@ -3080,6 +3694,7 @@
                           "type": "string"
                         }
                       ],
+                      "description": "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1.",
                       "x-kubernetes-int-or-string": true
                     },
                     "slowStartAdditiveIncrease": {
@@ -3091,9 +3706,11 @@
                           "type": "string"
                         }
                       ],
+                      "description": "SlowStartAdditiveIncrease Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Default value is 5.",
                       "x-kubernetes-int-or-string": true
                     },
                     "slowStartIntervalDuration": {
+                      "description": "SlowStartIntervalDuration the duration between to 2 Default value is 1min.",
                       "type": "string"
                     }
                   },
@@ -3101,6 +3718,7 @@
                   "additionalProperties": false
                 },
                 "updateStrategyType": {
+                  "description": "The update strategy used for the DaemonSet.",
                   "type": "string"
                 }
               },
@@ -3108,17 +3726,22 @@
               "additionalProperties": false
             },
             "dnsConfig": {
+              "description": "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.",
               "properties": {
                 "nameservers": {
+                  "description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "options": {
+                  "description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
                   "items": {
+                    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
                     "properties": {
                       "name": {
+                        "description": "Required.",
                         "type": "string"
                       },
                       "value": {
@@ -3131,6 +3754,7 @@
                   "type": "array"
                 },
                 "searches": {
+                  "description": "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.",
                   "items": {
                     "type": "string"
                   },
@@ -3141,31 +3765,42 @@
               "additionalProperties": false
             },
             "dnsPolicy": {
+              "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.",
               "type": "string"
             },
             "enabled": {
+              "description": "Enabled",
               "type": "boolean"
             },
             "env": {
+              "description": "Environment variables for all Datadog Agents. See also: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables",
               "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
                 "properties": {
                   "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                     "type": "string"
                   },
                   "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
                     "type": "string"
                   },
                   "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                     "properties": {
                       "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
                         "properties": {
                           "key": {
+                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                             "type": "string"
                           },
                           "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -3176,11 +3811,14 @@
                         "additionalProperties": false
                       },
                       "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                         "properties": {
                           "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                             "type": "string"
                           },
                           "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
                             "type": "string"
                           }
                         },
@@ -3191,8 +3829,10 @@
                         "additionalProperties": false
                       },
                       "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                         "properties": {
                           "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
                             "type": "string"
                           },
                           "divisor": {
@@ -3204,10 +3844,12 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
                           "resource": {
+                            "description": "Required: resource to select",
                             "type": "string"
                           }
                         },
@@ -3218,14 +3860,18 @@
                         "additionalProperties": false
                       },
                       "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
                         "properties": {
                           "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                             "type": "string"
                           },
                           "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -3253,26 +3899,35 @@
               "x-kubernetes-list-type": "map"
             },
             "hostNetwork": {
+              "description": "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.",
               "type": "boolean"
             },
             "hostPID": {
+              "description": "Use the host's pid namespace. Optional: Default to false.",
               "type": "boolean"
             },
             "image": {
+              "description": "The container image of the Datadog Agent.",
               "properties": {
                 "jmxEnabled": {
+                  "description": "Define whether the Agent image should support JMX. To be used if the Name field does not correspond to a full image string.",
                   "type": "boolean"
                 },
                 "name": {
+                  "description": "Define the image to use: Use \"gcr.io/datadoghq/agent:latest\" for Datadog Agent 7. Use \"datadog/dogstatsd:latest\" for standalone Datadog Agent DogStatsD 7. Use \"gcr.io/datadoghq/cluster-agent:latest\" for Datadog Cluster Agent. Use \"agent\" with the registry and tag configurations for <registry>/agent:<tag>. Use \"cluster-agent\" with the registry and tag configurations for <registry>/cluster-agent:<tag>. If the name is the full image string\u2014`<name>:<tag>` or `<registry>/<name>:<tag>`, then `tag`, `jmxEnabled`, and `global.registry` values are ignored. Otherwise, image string is created by overriding default settings with supplied `name`, `tag`, and `jmxEnabled` values; image string is created using default registry unless `global.registry` is configured.",
                   "type": "string"
                 },
                 "pullPolicy": {
+                  "description": "The Kubernetes pull policy: Use Always, Never, or IfNotPresent.",
                   "type": "string"
                 },
                 "pullSecrets": {
+                  "description": "It is possible to specify Docker registry credentials. See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
                   "items": {
+                    "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
                     "properties": {
                       "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                         "type": "string"
                       }
                     },
@@ -3282,6 +3937,7 @@
                   "type": "array"
                 },
                 "tag": {
+                  "description": "Define the image tag to use. To be used if the Name field does not correspond to a full image string.",
                   "type": "string"
                 }
               },
@@ -3289,17 +3945,22 @@
               "additionalProperties": false
             },
             "keepAnnotations": {
+              "description": "KeepAnnotations allows the specification of annotations not managed by the Operator that will be kept on Agent DaemonSet. All annotations containing 'datadoghq.com' are always included. This field uses glob syntax.",
               "type": "string"
             },
             "keepLabels": {
+              "description": "KeepLabels allows the specification of labels not managed by the Operator that will be kept on Agent DaemonSet. All labels containing 'datadoghq.com' are always included. This field uses glob syntax.",
               "type": "string"
             },
             "localService": {
+              "description": "Options to customize the internal traffic policy service",
               "properties": {
                 "forceLocalServiceEnable": {
+                  "description": "Force the creation of the internal traffic policy service to target the agent running on the local node. By default, the internal traffic service is created only on Kubernetes 1.22+ where the feature became beta and enabled by default. This option allows to force the creation of the internal traffic service on kubernetes 1.21 where the feature was alpha and required a feature gate to be explicitly enabled.",
                   "type": "boolean"
                 },
                 "overrideName": {
+                  "description": "Name of the internal traffic service to target the agent running on the local node",
                   "type": "string"
                 }
               },
@@ -3307,30 +3968,39 @@
               "additionalProperties": false
             },
             "log": {
+              "description": "Log Agent configuration",
               "properties": {
                 "containerCollectUsingFiles": {
+                  "description": "Collect logs from files in `/var/log/pods instead` of using the container runtime API. Collecting logs from files is usually the most efficient way of collecting logs. See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup Default is true",
                   "type": "boolean"
                 },
                 "containerLogsPath": {
+                  "description": "Allows log collection from the container log path. Set to a different path if you are not using the Docker runtime. See also: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#create-manifest Defaults to `/var/lib/docker/containers`",
                   "type": "string"
                 },
                 "containerSymlinksPath": {
+                  "description": "Allows the log collection to use symbolic links in this directory to validate container ID -> pod. Defaults to `/var/log/containers`",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "Enable this option to activate Datadog Agent log collection. See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup",
                   "type": "boolean"
                 },
                 "logsConfigContainerCollectAll": {
+                  "description": "Enable this option to allow log collection for all containers. See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup",
                   "type": "boolean"
                 },
                 "openFilesLimit": {
+                  "description": "Sets the maximum number of log files that the Datadog Agent tails. Increasing this limit can increase resource consumption of the Agent. See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup Default is 100",
                   "format": "int32",
                   "type": "integer"
                 },
                 "podLogsPath": {
+                  "description": "Allows log collection from pod log path. Defaults to `/var/log/pods`.",
                   "type": "string"
                 },
                 "tempStoragePath": {
+                  "description": "This path (always mounted from the host) is used by Datadog Agent to store information about processed log files. If the Datadog Agent is restarted, it starts tailing the log files immediately. Default to `/var/lib/datadog-agent/logs`",
                   "type": "string"
                 }
               },
@@ -3338,23 +4008,32 @@
               "additionalProperties": false
             },
             "networkPolicy": {
+              "description": "Provide Agent Network Policy configuration",
               "properties": {
                 "create": {
+                  "description": "If true, create a NetworkPolicy for the current agent.",
                   "type": "boolean"
                 },
                 "dnsSelectorEndpoints": {
+                  "description": "Cilium selector of the DNS\u202fserver entity.",
                   "items": {
+                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
                     "properties": {
                       "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                         "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                           "properties": {
                             "key": {
+                              "description": "key is the label key that the selector applies to.",
                               "type": "string"
                             },
                             "operator": {
+                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                               "type": "string"
                             },
                             "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                               "items": {
                                 "type": "string"
                               },
@@ -3374,6 +4053,7 @@
                         "additionalProperties": {
                           "type": "string"
                         },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                         "type": "object"
                       }
                     },
@@ -3384,6 +4064,7 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "flavor": {
+                  "description": "Which network policy to use. Can be `kubernetes` or `cilium`.",
                   "type": "string"
                 }
               },
@@ -3391,17 +4072,23 @@
               "additionalProperties": false
             },
             "otlp": {
+              "description": "OTLP ingest configuration",
               "properties": {
                 "receiver": {
+                  "description": "Receiver contains configuration for the OTLP ingest receiver.",
                   "properties": {
                     "protocols": {
+                      "description": "Protocols contains configuration for the OTLP ingest receiver protocols.",
                       "properties": {
                         "grpc": {
+                          "description": "GRPC contains configuration for the OTLP ingest OTLP/gRPC receiver.",
                           "properties": {
                             "enabled": {
+                              "description": "Enable the OTLP/gRPC endpoint.",
                               "type": "boolean"
                             },
                             "endpoint": {
+                              "description": "Endpoint for OTLP/gRPC. gRPC supports several naming schemes: https://github.com/grpc/grpc/blob/master/doc/naming.md The Datadog Operator supports only 'host:port' (usually '0.0.0.0:port'). Default: '0.0.0.0:4317'.",
                               "type": "string"
                             }
                           },
@@ -3409,11 +4096,14 @@
                           "additionalProperties": false
                         },
                         "http": {
+                          "description": "HTTP contains configuration for the OTLP ingest OTLP/HTTP receiver.",
                           "properties": {
                             "enabled": {
+                              "description": "Enable the OTLP/HTTP endpoint.",
                               "type": "boolean"
                             },
                             "endpoint": {
+                              "description": "Endpoint for OTLP/HTTP. Default: '0.0.0.0:4318'.",
                               "type": "string"
                             }
                           },
@@ -3433,11 +4123,14 @@
               "additionalProperties": false
             },
             "priorityClassName": {
+              "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
               "type": "string"
             },
             "process": {
+              "description": "Process Agent configuration",
               "properties": {
                 "args": {
+                  "description": "Args allows the specification of extra args to `Command` parameter",
                   "items": {
                     "type": "string"
                   },
@@ -3445,6 +4138,7 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "command": {
+                  "description": "Command allows the specification of custom entrypoint for Process Agent container",
                   "items": {
                     "type": "string"
                   },
@@ -3452,28 +4146,38 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "enabled": {
+                  "description": "Enable the Process Agent container. See also: https://docs.datadoghq.com/infrastructure/process/?tab=kubernetes#installation",
                   "type": "boolean"
                 },
                 "env": {
+                  "description": "The Datadog Agent supports many environment variables. See also: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables",
                   "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
                     "properties": {
                       "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                         "type": "string"
                       },
                       "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
                         "type": "string"
                       },
                       "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                         "properties": {
                           "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
                             "properties": {
                               "key": {
+                                "description": "The key to select.",
                                 "type": "string"
                               },
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -3484,11 +4188,14 @@
                             "additionalProperties": false
                           },
                           "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                             "properties": {
                               "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                 "type": "string"
                               },
                               "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
                                 "type": "string"
                               }
                             },
@@ -3499,8 +4206,10 @@
                             "additionalProperties": false
                           },
                           "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                             "properties": {
                               "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
                                 "type": "string"
                               },
                               "divisor": {
@@ -3512,10 +4221,12 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                 "x-kubernetes-int-or-string": true
                               },
                               "resource": {
+                                "description": "Required: resource to select",
                                 "type": "string"
                               }
                             },
@@ -3526,14 +4237,18 @@
                             "additionalProperties": false
                           },
                           "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
                             "properties": {
                               "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -3561,9 +4276,11 @@
                   "x-kubernetes-list-type": "map"
                 },
                 "processCollectionEnabled": {
+                  "description": "false (default): Only collect containers if available. true: collect process information as well. Note: If enabled, /etc/passwd is automatically mounted to allow username resolution.",
                   "type": "boolean"
                 },
                 "resources": {
+                  "description": "Datadog Process Agent resource requests and limits. Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class. See also: http://kubernetes.io/docs/user-guide/compute-resources/",
                   "properties": {
                     "limits": {
                       "additionalProperties": {
@@ -3578,6 +4295,7 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
+                      "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                       "type": "object"
                     },
                     "requests": {
@@ -3593,6 +4311,7 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
+                      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                       "type": "object"
                     }
                   },
@@ -3600,24 +4319,32 @@
                   "additionalProperties": false
                 },
                 "volumeMounts": {
+                  "description": "Specify additional volume mounts in the Process Agent container.",
                   "items": {
+                    "description": "VolumeMount describes a mounting of a Volume within a container.",
                     "properties": {
                       "mountPath": {
+                        "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
                         "type": "string"
                       },
                       "mountPropagation": {
+                        "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
                         "type": "string"
                       },
                       "name": {
+                        "description": "This must match the Name of a Volume.",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
                         "type": "boolean"
                       },
                       "subPath": {
+                        "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
                         "type": "string"
                       },
                       "subPathExpr": {
+                        "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
                         "type": "string"
                       }
                     },
@@ -3640,11 +4367,14 @@
               "additionalProperties": false
             },
             "rbac": {
+              "description": "RBAC configuration of the Agent.",
               "properties": {
                 "create": {
+                  "description": "Used to configure RBAC resources creation.",
                   "type": "boolean"
                 },
                 "serviceAccountName": {
+                  "description": "Used to set up the service account name to use. Ignored if the field Create is true.",
                   "type": "string"
                 }
               },
@@ -3652,8 +4382,10 @@
               "additionalProperties": false
             },
             "security": {
+              "description": "Security Agent configuration",
               "properties": {
                 "args": {
+                  "description": "Args allows the specification of extra args to `Command` parameter",
                   "items": {
                     "type": "string"
                   },
@@ -3661,6 +4393,7 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "command": {
+                  "description": "Command allows the specification of custom entrypoint for Security Agent container",
                   "items": {
                     "type": "string"
                   },
@@ -3668,26 +4401,35 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "compliance": {
+                  "description": "Compliance configuration.",
                   "properties": {
                     "checkInterval": {
+                      "description": "Check interval.",
                       "type": "string"
                     },
                     "configDir": {
+                      "description": "Config dir containing compliance benchmarks.",
                       "properties": {
                         "configMapName": {
+                          "description": "ConfigMapName name of a ConfigMap used to mount a directory.",
                           "type": "string"
                         },
                         "items": {
+                          "description": "items mapping between configMap data key and file path mount.",
                           "items": {
+                            "description": "Maps a string key to a path within a volume.",
                             "properties": {
                               "key": {
+                                "description": "key is the key to project.",
                                 "type": "string"
                               },
                               "mode": {
+                                "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                 "format": "int32",
                                 "type": "integer"
                               },
                               "path": {
+                                "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                 "type": "string"
                               }
                             },
@@ -3709,6 +4451,7 @@
                       "additionalProperties": false
                     },
                     "enabled": {
+                      "description": "Enables continuous compliance monitoring.",
                       "type": "boolean"
                     }
                   },
@@ -3716,25 +4459,34 @@
                   "additionalProperties": false
                 },
                 "env": {
+                  "description": "The Datadog Security Agent supports many environment variables. See also: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables",
                   "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
                     "properties": {
                       "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                         "type": "string"
                       },
                       "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
                         "type": "string"
                       },
                       "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                         "properties": {
                           "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
                             "properties": {
                               "key": {
+                                "description": "The key to select.",
                                 "type": "string"
                               },
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -3745,11 +4497,14 @@
                             "additionalProperties": false
                           },
                           "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                             "properties": {
                               "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                 "type": "string"
                               },
                               "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
                                 "type": "string"
                               }
                             },
@@ -3760,8 +4515,10 @@
                             "additionalProperties": false
                           },
                           "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                             "properties": {
                               "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
                                 "type": "string"
                               },
                               "divisor": {
@@ -3773,10 +4530,12 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                 "x-kubernetes-int-or-string": true
                               },
                               "resource": {
+                                "description": "Required: resource to select",
                                 "type": "string"
                               }
                             },
@@ -3787,14 +4546,18 @@
                             "additionalProperties": false
                           },
                           "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
                             "properties": {
                               "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -3822,6 +4585,7 @@
                   "x-kubernetes-list-type": "map"
                 },
                 "resources": {
+                  "description": "Datadog Security Agent resource requests and limits. Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class. See also: http://kubernetes.io/docs/user-guide/compute-resources/",
                   "properties": {
                     "limits": {
                       "additionalProperties": {
@@ -3836,6 +4600,7 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
+                      "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                       "type": "object"
                     },
                     "requests": {
@@ -3851,6 +4616,7 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
+                      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                       "type": "object"
                     }
                   },
@@ -3858,26 +4624,35 @@
                   "additionalProperties": false
                 },
                 "runtime": {
+                  "description": "Runtime security configuration.",
                   "properties": {
                     "enabled": {
+                      "description": "Enables runtime security features.",
                       "type": "boolean"
                     },
                     "policiesDir": {
+                      "description": "ConfigDir containing security policies.",
                       "properties": {
                         "configMapName": {
+                          "description": "ConfigMapName name of a ConfigMap used to mount a directory.",
                           "type": "string"
                         },
                         "items": {
+                          "description": "items mapping between configMap data key and file path mount.",
                           "items": {
+                            "description": "Maps a string key to a path within a volume.",
                             "properties": {
                               "key": {
+                                "description": "key is the key to project.",
                                 "type": "string"
                               },
                               "mode": {
+                                "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                 "format": "int32",
                                 "type": "integer"
                               },
                               "path": {
+                                "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                 "type": "string"
                               }
                             },
@@ -3899,8 +4674,10 @@
                       "additionalProperties": false
                     },
                     "syscallMonitor": {
+                      "description": "Syscall monitor configuration.",
                       "properties": {
                         "enabled": {
+                          "description": "Enabled enables syscall monitor",
                           "type": "boolean"
                         }
                       },
@@ -3912,24 +4689,32 @@
                   "additionalProperties": false
                 },
                 "volumeMounts": {
+                  "description": "Specify additional volume mounts in the Security Agent container.",
                   "items": {
+                    "description": "VolumeMount describes a mounting of a Volume within a container.",
                     "properties": {
                       "mountPath": {
+                        "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
                         "type": "string"
                       },
                       "mountPropagation": {
+                        "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
                         "type": "string"
                       },
                       "name": {
+                        "description": "This must match the Name of a Volume.",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
                         "type": "boolean"
                       },
                       "subPath": {
+                        "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
                         "type": "string"
                       },
                       "subPathExpr": {
+                        "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
                         "type": "string"
                       }
                     },
@@ -3952,11 +4737,14 @@
               "additionalProperties": false
             },
             "systemProbe": {
+              "description": "SystemProbe configuration",
               "properties": {
                 "appArmorProfileName": {
+                  "description": "AppArmorProfileName specify a apparmor profile.",
                   "type": "string"
                 },
                 "args": {
+                  "description": "Args allows the specification of extra args to `Command` parameter",
                   "items": {
                     "type": "string"
                   },
@@ -3964,12 +4752,15 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "bpfDebugEnabled": {
+                  "description": "BPFDebugEnabled logging for kernel debug.",
                   "type": "boolean"
                 },
                 "collectDNSStats": {
+                  "description": "CollectDNSStats enables DNS stat collection.",
                   "type": "boolean"
                 },
                 "command": {
+                  "description": "Command allows the specification of custom entrypoint for System Probe container",
                   "items": {
                     "type": "string"
                   },
@@ -3977,19 +4768,25 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "conntrackEnabled": {
+                  "description": "ConntrackEnabled enable the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data. See also: http://conntrack-tools.netfilter.org/",
                   "type": "boolean"
                 },
                 "customConfig": {
+                  "description": "Enable custom configuration for system-probe, corresponding to the system-probe.yaml config file. This custom configuration has less priority than all settings above.",
                   "properties": {
                     "configData": {
+                      "description": "ConfigData corresponds to the configuration file content.",
                       "type": "string"
                     },
                     "configMap": {
+                      "description": "Enable to specify a reference to an already existing ConfigMap.",
                       "properties": {
                         "fileKey": {
+                          "description": "FileKey corresponds to the key used in the ConfigMap.Data to store the configuration file content.",
                           "type": "string"
                         },
                         "name": {
+                          "description": "The name of source ConfigMap.",
                           "type": "string"
                         }
                       },
@@ -4001,38 +4798,51 @@
                   "additionalProperties": false
                 },
                 "debugPort": {
+                  "description": "DebugPort Specify the port to expose pprof and expvar for system-probe agent.",
                   "format": "int32",
                   "type": "integer"
                 },
                 "enableOOMKill": {
+                  "description": "EnableOOMKill enables the OOM kill eBPF-based check.",
                   "type": "boolean"
                 },
                 "enableTCPQueueLength": {
+                  "description": "EnableTCPQueueLength enables the TCP queue length eBPF-based check.",
                   "type": "boolean"
                 },
                 "enabled": {
+                  "description": "Enable this to activate live process monitoring. Note: /etc/passwd is automatically mounted to allow username resolution. See also: https://docs.datadoghq.com/infrastructure/process/?tab=kubernetes#installation",
                   "type": "boolean"
                 },
                 "env": {
+                  "description": "The Datadog SystemProbe supports many environment variables. See also: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables",
                   "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
                     "properties": {
                       "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                         "type": "string"
                       },
                       "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
                         "type": "string"
                       },
                       "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                         "properties": {
                           "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
                             "properties": {
                               "key": {
+                                "description": "The key to select.",
                                 "type": "string"
                               },
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -4043,11 +4853,14 @@
                             "additionalProperties": false
                           },
                           "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                             "properties": {
                               "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                 "type": "string"
                               },
                               "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
                                 "type": "string"
                               }
                             },
@@ -4058,8 +4871,10 @@
                             "additionalProperties": false
                           },
                           "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                             "properties": {
                               "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
                                 "type": "string"
                               },
                               "divisor": {
@@ -4071,10 +4886,12 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                 "x-kubernetes-int-or-string": true
                               },
                               "resource": {
+                                "description": "Required: resource to select",
                                 "type": "string"
                               }
                             },
@@ -4085,14 +4902,18 @@
                             "additionalProperties": false
                           },
                           "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
                             "properties": {
                               "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -4120,6 +4941,7 @@
                   "x-kubernetes-list-type": "map"
                 },
                 "resources": {
+                  "description": "Datadog SystemProbe resource requests and limits. Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class. See also: http://kubernetes.io/docs/user-guide/compute-resources/",
                   "properties": {
                     "limits": {
                       "additionalProperties": {
@@ -4134,6 +4956,7 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
+                      "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                       "type": "object"
                     },
                     "requests": {
@@ -4149,6 +4972,7 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
+                      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                       "type": "object"
                     }
                   },
@@ -4156,29 +4980,39 @@
                   "additionalProperties": false
                 },
                 "secCompCustomProfileConfigMap": {
+                  "description": "SecCompCustomProfileConfigMap specify a pre-existing ConfigMap containing a custom SecComp profile. This ConfigMap must contain a file named system-probe-seccomp.json.",
                   "type": "string"
                 },
                 "secCompProfileName": {
+                  "description": "SecCompProfileName specify a seccomp profile.",
                   "type": "string"
                 },
                 "secCompRootPath": {
+                  "description": "SecCompRootPath specify the seccomp profile root directory.",
                   "type": "string"
                 },
                 "securityContext": {
+                  "description": "You can modify the security context used to run the containers by modifying the label type.",
                   "properties": {
                     "allowPrivilegeEscalation": {
+                      "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
                       "type": "boolean"
                     },
                     "capabilities": {
+                      "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
                       "properties": {
                         "add": {
+                          "description": "Added capabilities",
                           "items": {
+                            "description": "Capability represent POSIX capabilities type",
                             "type": "string"
                           },
                           "type": "array"
                         },
                         "drop": {
+                          "description": "Removed capabilities",
                           "items": {
+                            "description": "Capability represent POSIX capabilities type",
                             "type": "string"
                           },
                           "type": "array"
@@ -4188,37 +5022,48 @@
                       "additionalProperties": false
                     },
                     "privileged": {
+                      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
                       "type": "boolean"
                     },
                     "procMount": {
+                      "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
                       "type": "string"
                     },
                     "readOnlyRootFilesystem": {
+                      "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
                       "type": "boolean"
                     },
                     "runAsGroup": {
+                      "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "runAsNonRoot": {
+                      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
                       "type": "boolean"
                     },
                     "runAsUser": {
+                      "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "seLinuxOptions": {
+                      "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
                       "properties": {
                         "level": {
+                          "description": "Level is SELinux level label that applies to the container.",
                           "type": "string"
                         },
                         "role": {
+                          "description": "Role is a SELinux role label that applies to the container.",
                           "type": "string"
                         },
                         "type": {
+                          "description": "Type is a SELinux type label that applies to the container.",
                           "type": "string"
                         },
                         "user": {
+                          "description": "User is a SELinux user label that applies to the container.",
                           "type": "string"
                         }
                       },
@@ -4226,11 +5071,14 @@
                       "additionalProperties": false
                     },
                     "seccompProfile": {
+                      "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
                       "properties": {
                         "localhostProfile": {
+                          "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
                           "type": "string"
                         },
                         "type": {
+                          "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
                           "type": "string"
                         }
                       },
@@ -4241,17 +5089,22 @@
                       "additionalProperties": false
                     },
                     "windowsOptions": {
+                      "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
                       "properties": {
                         "gmsaCredentialSpec": {
+                          "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
                           "type": "string"
                         },
                         "gmsaCredentialSpecName": {
+                          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                           "type": "string"
                         },
                         "hostProcess": {
+                          "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
                           "type": "boolean"
                         },
                         "runAsUserName": {
+                          "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
                           "type": "string"
                         }
                       },
@@ -4263,24 +5116,32 @@
                   "additionalProperties": false
                 },
                 "volumeMounts": {
+                  "description": "Specify additional volume mounts in the Security Agent container.",
                   "items": {
+                    "description": "VolumeMount describes a mounting of a Volume within a container.",
                     "properties": {
                       "mountPath": {
+                        "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
                         "type": "string"
                       },
                       "mountPropagation": {
+                        "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
                         "type": "string"
                       },
                       "name": {
+                        "description": "This must match the Name of a Volume.",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
                         "type": "boolean"
                       },
                       "subPath": {
+                        "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
                         "type": "string"
                       },
                       "subPathExpr": {
+                        "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
                         "type": "string"
                       }
                     },
@@ -4303,6 +5164,7 @@
               "additionalProperties": false
             },
             "useExtendedDaemonset": {
+              "description": "UseExtendedDaemonset use ExtendedDaemonset for Agent deployment. default value is false.",
               "type": "boolean"
             }
           },
@@ -4310,38 +5172,51 @@
           "additionalProperties": false
         },
         "clusterAgent": {
+          "description": "The desired state of the Cluster Agent as a deployment.",
           "properties": {
             "additionalAnnotations": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "AdditionalAnnotations provide annotations that will be added to the Cluster Agent Pods.",
               "type": "object"
             },
             "additionalLabels": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "AdditionalLabels provide labels that will be added to the Cluster Agent Pods.",
               "type": "object"
             },
             "affinity": {
+              "description": "If specified, the pod's scheduling constraints.",
               "properties": {
                 "nodeAffinity": {
+                  "description": "Describes node affinity scheduling rules for the pod.",
                   "properties": {
                     "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
                       "items": {
+                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
                         "properties": {
                           "preference": {
+                            "description": "A node selector term, associated with the corresponding weight.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -4358,15 +5233,20 @@
                                 "type": "array"
                               },
                               "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -4387,6 +5267,7 @@
                             "additionalProperties": false
                           },
                           "weight": {
+                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -4401,20 +5282,28 @@
                       "type": "array"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
                       "properties": {
                         "nodeSelectorTerms": {
+                          "description": "Required. A list of node selector terms. The terms are ORed.",
                           "items": {
+                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -4431,15 +5320,20 @@
                                 "type": "array"
                               },
                               "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -4473,24 +5367,34 @@
                   "additionalProperties": false
                 },
                 "podAffinity": {
+                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
                   "properties": {
                     "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
                       "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
                         "properties": {
                           "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
                             "properties": {
                               "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -4510,6 +5414,7 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
@@ -4517,17 +5422,23 @@
                                 "additionalProperties": false
                               },
                               "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -4547,6 +5458,7 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
@@ -4554,12 +5466,14 @@
                                 "additionalProperties": false
                               },
                               "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                                 "items": {
                                   "type": "string"
                                 },
                                 "type": "array"
                               },
                               "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                 "type": "string"
                               }
                             },
@@ -4570,6 +5484,7 @@
                             "additionalProperties": false
                           },
                           "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -4584,20 +5499,28 @@
                       "type": "array"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
                       "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
                         "properties": {
                           "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -4617,6 +5540,7 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
@@ -4624,17 +5548,23 @@
                             "additionalProperties": false
                           },
                           "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -4654,6 +5584,7 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
@@ -4661,12 +5592,14 @@
                             "additionalProperties": false
                           },
                           "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                             "type": "string"
                           }
                         },
@@ -4683,24 +5616,34 @@
                   "additionalProperties": false
                 },
                 "podAntiAffinity": {
+                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
                   "properties": {
                     "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
                       "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
                         "properties": {
                           "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
                             "properties": {
                               "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -4720,6 +5663,7 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
@@ -4727,17 +5671,23 @@
                                 "additionalProperties": false
                               },
                               "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -4757,6 +5707,7 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
@@ -4764,12 +5715,14 @@
                                 "additionalProperties": false
                               },
                               "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                                 "items": {
                                   "type": "string"
                                 },
                                 "type": "array"
                               },
                               "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                 "type": "string"
                               }
                             },
@@ -4780,6 +5733,7 @@
                             "additionalProperties": false
                           },
                           "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -4794,20 +5748,28 @@
                       "type": "array"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
                       "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
                         "properties": {
                           "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -4827,6 +5789,7 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
@@ -4834,17 +5797,23 @@
                             "additionalProperties": false
                           },
                           "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -4864,6 +5833,7 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
@@ -4871,12 +5841,14 @@
                             "additionalProperties": false
                           },
                           "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                             "type": "string"
                           }
                         },
@@ -4897,19 +5869,25 @@
               "additionalProperties": false
             },
             "config": {
+              "description": "Cluster Agent configuration.",
               "properties": {
                 "admissionController": {
+                  "description": "Configure the Admission Controller.",
                   "properties": {
                     "agentCommunicationMode": {
+                      "description": "agentCommunicationMode corresponds to the mode used by the Datadog application libraries to communicate with the Agent. It can be \"hostip\", \"service\", or \"socket\".",
                       "type": "string"
                     },
                     "enabled": {
+                      "description": "Enable the admission controller to be able to inject APM/Dogstatsd config and standard tags (env, service, version) automatically into your pods.",
                       "type": "boolean"
                     },
                     "mutateUnlabelled": {
+                      "description": "MutateUnlabelled enables injecting config without having the pod label 'admission.datadoghq.com/enabled=\"true\"'.",
                       "type": "boolean"
                     },
                     "serviceName": {
+                      "description": "ServiceName corresponds to the webhook service name.",
                       "type": "string"
                     }
                   },
@@ -4917,6 +5895,7 @@
                   "additionalProperties": false
                 },
                 "args": {
+                  "description": "Args allows the specification of extra args to `Command` parameter",
                   "items": {
                     "type": "string"
                   },
@@ -4924,12 +5903,15 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "clusterChecksEnabled": {
+                  "description": "Enable the Cluster Checks and Endpoint Checks feature on both the Cluster Agent and the daemonset. See also: https://docs.datadoghq.com/agent/cluster_agent/clusterchecks/ https://docs.datadoghq.com/agent/cluster_agent/endpointschecks/ Autodiscovery via Kube Service annotations is automatically enabled.",
                   "type": "boolean"
                 },
                 "collectEvents": {
+                  "description": "Enable this to start event collection from the kubernetes API. See also: https://docs.datadoghq.com/agent/cluster_agent/event_collection/",
                   "type": "boolean"
                 },
                 "command": {
+                  "description": "Command allows the specification of custom entrypoint for Cluster Agent container",
                   "items": {
                     "type": "string"
                   },
@@ -4937,21 +5919,28 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "confd": {
+                  "description": "Confd Provide additional cluster check configurations. Each key will become a file in /conf.d. see https://docs.datadoghq.com/agent/autodiscovery/ for more details.",
                   "properties": {
                     "configMapName": {
+                      "description": "ConfigMapName name of a ConfigMap used to mount a directory.",
                       "type": "string"
                     },
                     "items": {
+                      "description": "items mapping between configMap data key and file path mount.",
                       "items": {
+                        "description": "Maps a string key to a path within a volume.",
                         "properties": {
                           "key": {
+                            "description": "key is the key to project.",
                             "type": "string"
                           },
                           "mode": {
+                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "path": {
+                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                             "type": "string"
                           }
                         },
@@ -4973,25 +5962,34 @@
                   "additionalProperties": false
                 },
                 "env": {
+                  "description": "The Datadog Agent supports many environment variables. See also: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables",
                   "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
                     "properties": {
                       "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                         "type": "string"
                       },
                       "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
                         "type": "string"
                       },
                       "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                         "properties": {
                           "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
                             "properties": {
                               "key": {
+                                "description": "The key to select.",
                                 "type": "string"
                               },
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -5002,11 +6000,14 @@
                             "additionalProperties": false
                           },
                           "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                             "properties": {
                               "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                 "type": "string"
                               },
                               "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
                                 "type": "string"
                               }
                             },
@@ -5017,8 +6018,10 @@
                             "additionalProperties": false
                           },
                           "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                             "properties": {
                               "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
                                 "type": "string"
                               },
                               "divisor": {
@@ -5030,10 +6033,12 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                 "x-kubernetes-int-or-string": true
                               },
                               "resource": {
+                                "description": "Required: resource to select",
                                 "type": "string"
                               }
                             },
@@ -5044,14 +6049,18 @@
                             "additionalProperties": false
                           },
                           "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
                             "properties": {
                               "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -5079,21 +6088,28 @@
                   "x-kubernetes-list-type": "map"
                 },
                 "externalMetrics": {
+                  "description": "ExternalMetricsConfig contains the configuration of the external metrics provider in Cluster Agent.",
                   "properties": {
                     "credentials": {
+                      "description": "Datadog credentials used by external metrics server to query Datadog. If not set, the external metrics server uses the global .spec.Credentials",
                       "properties": {
                         "apiKey": {
+                          "description": "APIKey Set this to your Datadog API key before the Agent runs. See also: https://app.datadoghq.com/account/settings#agent/kubernetes",
                           "type": "string"
                         },
                         "apiKeyExistingSecret": {
+                          "description": "APIKeyExistingSecret is DEPRECATED. In order to pass the API key through an existing secret, please consider \"apiSecret\" instead. If set, this parameter takes precedence over \"apiKey\".",
                           "type": "string"
                         },
                         "apiSecret": {
+                          "description": "APISecret Use existing Secret which stores API key instead of creating a new one. If set, this parameter takes precedence over \"apiKey\" and \"apiKeyExistingSecret\".",
                           "properties": {
                             "keyName": {
+                              "description": "KeyName is the key of the secret to use.",
                               "type": "string"
                             },
                             "secretName": {
+                              "description": "SecretName is the name of the secret.",
                               "type": "string"
                             }
                           },
@@ -5104,17 +6120,22 @@
                           "additionalProperties": false
                         },
                         "appKey": {
+                          "description": "If you are using clusterAgent.metricsProvider.enabled = true, you must set a Datadog application key for read access to your metrics.",
                           "type": "string"
                         },
                         "appKeyExistingSecret": {
+                          "description": "AppKeyExistingSecret is DEPRECATED. In order to pass the APP key through an existing secret, please consider \"appSecret\" instead. If set, this parameter takes precedence over \"appKey\".",
                           "type": "string"
                         },
                         "appSecret": {
+                          "description": "APPSecret Use existing Secret which stores API key instead of creating a new one. If set, this parameter takes precedence over \"apiKey\" and \"appKeyExistingSecret\".",
                           "properties": {
                             "keyName": {
+                              "description": "KeyName is the key of the secret to use.",
                               "type": "string"
                             },
                             "secretName": {
+                              "description": "SecretName is the name of the secret.",
                               "type": "string"
                             }
                           },
@@ -5129,19 +6150,24 @@
                       "additionalProperties": false
                     },
                     "enabled": {
+                      "description": "Enable the metricsProvider to be able to scale based on metrics in Datadog.",
                       "type": "boolean"
                     },
                     "endpoint": {
+                      "description": "Override the API endpoint for the external metrics server. Defaults to .spec.agent.config.ddUrl or \"https://app.datadoghq.com\" if that's empty.",
                       "type": "string"
                     },
                     "port": {
+                      "description": "If specified configures the metricsProvider external metrics service port.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "useDatadogMetrics": {
+                      "description": "Enable usage of DatadogMetrics CRD (allow to scale on arbitrary queries).",
                       "type": "boolean"
                     },
                     "wpaController": {
+                      "description": "Enable informer and controller of the watermark pod autoscaler. NOTE: The WatermarkPodAutoscaler controller needs to be installed. See also: https://github.com/DataDog/watermarkpodautoscaler.",
                       "type": "boolean"
                     }
                   },
@@ -5149,13 +6175,16 @@
                   "additionalProperties": false
                 },
                 "healthPort": {
+                  "description": "HealthPort of the Agent container for internal liveness probe. Must be the same as the Liveness/Readiness probes.",
                   "format": "int32",
                   "type": "integer"
                 },
                 "logLevel": {
+                  "description": "Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off",
                   "type": "string"
                 },
                 "resources": {
+                  "description": "Datadog Cluster Agent resource requests and limits.",
                   "properties": {
                     "limits": {
                       "additionalProperties": {
@@ -5170,6 +6199,7 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
+                      "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                       "type": "object"
                     },
                     "requests": {
@@ -5185,6 +6215,7 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
+                      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                       "type": "object"
                     }
                   },
@@ -5192,37 +6223,48 @@
                   "additionalProperties": false
                 },
                 "securityContext": {
+                  "description": "Pod-level SecurityContext.",
                   "properties": {
                     "fsGroup": {
+                      "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "fsGroupChangePolicy": {
+                      "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.",
                       "type": "string"
                     },
                     "runAsGroup": {
+                      "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "runAsNonRoot": {
+                      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
                       "type": "boolean"
                     },
                     "runAsUser": {
+                      "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "seLinuxOptions": {
+                      "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
                       "properties": {
                         "level": {
+                          "description": "Level is SELinux level label that applies to the container.",
                           "type": "string"
                         },
                         "role": {
+                          "description": "Role is a SELinux role label that applies to the container.",
                           "type": "string"
                         },
                         "type": {
+                          "description": "Type is a SELinux type label that applies to the container.",
                           "type": "string"
                         },
                         "user": {
+                          "description": "User is a SELinux user label that applies to the container.",
                           "type": "string"
                         }
                       },
@@ -5230,11 +6272,14 @@
                       "additionalProperties": false
                     },
                     "seccompProfile": {
+                      "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.",
                       "properties": {
                         "localhostProfile": {
+                          "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
                           "type": "string"
                         },
                         "type": {
+                          "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
                           "type": "string"
                         }
                       },
@@ -5245,6 +6290,7 @@
                       "additionalProperties": false
                     },
                     "supplementalGroups": {
+                      "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container. Note that this field cannot be set when spec.os.name is windows.",
                       "items": {
                         "format": "int64",
                         "type": "integer"
@@ -5252,12 +6298,16 @@
                       "type": "array"
                     },
                     "sysctls": {
+                      "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
                       "items": {
+                        "description": "Sysctl defines a kernel parameter to be set",
                         "properties": {
                           "name": {
+                            "description": "Name of a property to set",
                             "type": "string"
                           },
                           "value": {
+                            "description": "Value of a property to set",
                             "type": "string"
                           }
                         },
@@ -5271,17 +6321,22 @@
                       "type": "array"
                     },
                     "windowsOptions": {
+                      "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
                       "properties": {
                         "gmsaCredentialSpec": {
+                          "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
                           "type": "string"
                         },
                         "gmsaCredentialSpecName": {
+                          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                           "type": "string"
                         },
                         "hostProcess": {
+                          "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
                           "type": "boolean"
                         },
                         "runAsUserName": {
+                          "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
                           "type": "string"
                         }
                       },
@@ -5293,24 +6348,32 @@
                   "additionalProperties": false
                 },
                 "volumeMounts": {
+                  "description": "Specify additional volume mounts in the Datadog Cluster Agent container.",
                   "items": {
+                    "description": "VolumeMount describes a mounting of a Volume within a container.",
                     "properties": {
                       "mountPath": {
+                        "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
                         "type": "string"
                       },
                       "mountPropagation": {
+                        "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
                         "type": "string"
                       },
                       "name": {
+                        "description": "This must match the Name of a Volume.",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
                         "type": "boolean"
                       },
                       "subPath": {
+                        "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
                         "type": "string"
                       },
                       "subPathExpr": {
+                        "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
                         "type": "string"
                       }
                     },
@@ -5329,21 +6392,28 @@
                   "x-kubernetes-list-type": "map"
                 },
                 "volumes": {
+                  "description": "Specify additional volumes in the Datadog Cluster Agent container.",
                   "items": {
+                    "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
                     "properties": {
                       "awsElasticBlockStore": {
+                        "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine",
                             "type": "string"
                           },
                           "partition": {
+                            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
                             "format": "int32",
                             "type": "integer"
                           },
                           "readOnly": {
+                            "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                             "type": "boolean"
                           },
                           "volumeID": {
+                            "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                             "type": "string"
                           }
                         },
@@ -5354,23 +6424,30 @@
                         "additionalProperties": false
                       },
                       "azureDisk": {
+                        "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
                         "properties": {
                           "cachingMode": {
+                            "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
                             "type": "string"
                           },
                           "diskName": {
+                            "description": "diskName is the Name of the data disk in the blob storage",
                             "type": "string"
                           },
                           "diskURI": {
+                            "description": "diskURI is the URI of data disk in the blob storage",
                             "type": "string"
                           },
                           "fsType": {
+                            "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                             "type": "string"
                           },
                           "kind": {
+                            "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           }
                         },
@@ -5382,14 +6459,18 @@
                         "additionalProperties": false
                       },
                       "azureFile": {
+                        "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.",
                         "properties": {
                           "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "secretName": {
+                            "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
                             "type": "string"
                           },
                           "shareName": {
+                            "description": "shareName is the azure share Name",
                             "type": "string"
                           }
                         },
@@ -5401,25 +6482,32 @@
                         "additionalProperties": false
                       },
                       "cephfs": {
+                        "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
                         "properties": {
                           "monitors": {
+                            "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "path": {
+                            "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                             "type": "boolean"
                           },
                           "secretFile": {
+                            "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                             "type": "string"
                           },
                           "secretRef": {
+                            "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -5427,6 +6515,7 @@
                             "additionalProperties": false
                           },
                           "user": {
+                            "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                             "type": "string"
                           }
                         },
@@ -5437,16 +6526,21 @@
                         "additionalProperties": false
                       },
                       "cinder": {
+                        "description": "cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -5454,6 +6548,7 @@
                             "additionalProperties": false
                           },
                           "volumeID": {
+                            "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                             "type": "string"
                           }
                         },
@@ -5464,22 +6559,29 @@
                         "additionalProperties": false
                       },
                       "configMap": {
+                        "description": "configMap represents a configMap that should populate this volume",
                         "properties": {
                           "defaultMode": {
+                            "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                             "items": {
+                              "description": "Maps a string key to a path within a volume.",
                               "properties": {
                                 "key": {
+                                  "description": "key is the key to project.",
                                   "type": "string"
                                 },
                                 "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                   "format": "int32",
                                   "type": "integer"
                                 },
                                 "path": {
+                                  "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                   "type": "string"
                                 }
                               },
@@ -5493,9 +6595,11 @@
                             "type": "array"
                           },
                           "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                             "type": "string"
                           },
                           "optional": {
+                            "description": "optional specify whether the ConfigMap or its keys must be defined",
                             "type": "boolean"
                           }
                         },
@@ -5503,16 +6607,21 @@
                         "additionalProperties": false
                       },
                       "csi": {
+                        "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
                         "properties": {
                           "driver": {
+                            "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
                             "type": "string"
                           },
                           "fsType": {
+                            "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
                             "type": "string"
                           },
                           "nodePublishSecretRef": {
+                            "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -5520,12 +6629,14 @@
                             "additionalProperties": false
                           },
                           "readOnly": {
+                            "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
                             "type": "boolean"
                           },
                           "volumeAttributes": {
                             "additionalProperties": {
                               "type": "string"
                             },
+                            "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
                             "type": "object"
                           }
                         },
@@ -5536,20 +6647,27 @@
                         "additionalProperties": false
                       },
                       "downwardAPI": {
+                        "description": "downwardAPI represents downward API about the pod that should populate this volume",
                         "properties": {
                           "defaultMode": {
+                            "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "items": {
+                            "description": "Items is a list of downward API volume file",
                             "items": {
+                              "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
                               "properties": {
                                 "fieldRef": {
+                                  "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
                                   "properties": {
                                     "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                       "type": "string"
                                     },
                                     "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
                                       "type": "string"
                                     }
                                   },
@@ -5560,15 +6678,19 @@
                                   "additionalProperties": false
                                 },
                                 "mode": {
+                                  "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                   "format": "int32",
                                   "type": "integer"
                                 },
                                 "path": {
+                                  "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
                                   "type": "string"
                                 },
                                 "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
                                   "properties": {
                                     "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
                                       "type": "string"
                                     },
                                     "divisor": {
@@ -5580,10 +6702,12 @@
                                           "type": "string"
                                         }
                                       ],
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                       "x-kubernetes-int-or-string": true
                                     },
                                     "resource": {
+                                      "description": "Required: resource to select",
                                       "type": "string"
                                     }
                                   },
@@ -5607,8 +6731,10 @@
                         "additionalProperties": false
                       },
                       "emptyDir": {
+                        "description": "emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                         "properties": {
                           "medium": {
+                            "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                             "type": "string"
                           },
                           "sizeLimit": {
@@ -5620,6 +6746,7 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           }
@@ -5628,29 +6755,38 @@
                         "additionalProperties": false
                       },
                       "ephemeral": {
+                        "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
                         "properties": {
                           "volumeClaimTemplate": {
+                            "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil.",
                             "properties": {
                               "metadata": {
+                                "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
                                 "type": "object"
                               },
                               "spec": {
+                                "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
                                 "properties": {
                                   "accessModes": {
+                                    "description": "accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
                                     "items": {
                                       "type": "string"
                                     },
                                     "type": "array"
                                   },
                                   "dataSource": {
+                                    "description": "dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.",
                                     "properties": {
                                       "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
                                         "type": "string"
                                       },
                                       "kind": {
+                                        "description": "Kind is the type of resource being referenced",
                                         "type": "string"
                                       },
                                       "name": {
+                                        "description": "Name is the name of resource being referenced",
                                         "type": "string"
                                       }
                                     },
@@ -5662,14 +6798,18 @@
                                     "additionalProperties": false
                                   },
                                   "dataSourceRef": {
+                                    "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.",
                                     "properties": {
                                       "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
                                         "type": "string"
                                       },
                                       "kind": {
+                                        "description": "Kind is the type of resource being referenced",
                                         "type": "string"
                                       },
                                       "name": {
+                                        "description": "Name is the name of resource being referenced",
                                         "type": "string"
                                       }
                                     },
@@ -5681,6 +6821,7 @@
                                     "additionalProperties": false
                                   },
                                   "resources": {
+                                    "description": "resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
                                     "properties": {
                                       "limits": {
                                         "additionalProperties": {
@@ -5695,6 +6836,7 @@
                                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                           "x-kubernetes-int-or-string": true
                                         },
+                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                                         "type": "object"
                                       },
                                       "requests": {
@@ -5710,6 +6852,7 @@
                                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                           "x-kubernetes-int-or-string": true
                                         },
+                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                                         "type": "object"
                                       }
                                     },
@@ -5717,17 +6860,23 @@
                                     "additionalProperties": false
                                   },
                                   "selector": {
+                                    "description": "selector is a label query over volumes to consider for binding.",
                                     "properties": {
                                       "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                         "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                           "properties": {
                                             "key": {
+                                              "description": "key is the label key that the selector applies to.",
                                               "type": "string"
                                             },
                                             "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                               "type": "string"
                                             },
                                             "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                               "items": {
                                                 "type": "string"
                                               },
@@ -5747,6 +6896,7 @@
                                         "additionalProperties": {
                                           "type": "string"
                                         },
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                         "type": "object"
                                       }
                                     },
@@ -5754,12 +6904,15 @@
                                     "additionalProperties": false
                                   },
                                   "storageClassName": {
+                                    "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
                                     "type": "string"
                                   },
                                   "volumeMode": {
+                                    "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
                                     "type": "string"
                                   },
                                   "volumeName": {
+                                    "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
                                     "type": "string"
                                   }
                                 },
@@ -5778,24 +6931,30 @@
                         "additionalProperties": false
                       },
                       "fc": {
+                        "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine",
                             "type": "string"
                           },
                           "lun": {
+                            "description": "lun is Optional: FC target lun number",
                             "format": "int32",
                             "type": "integer"
                           },
                           "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "targetWWNs": {
+                            "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "wwids": {
+                            "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
                             "items": {
                               "type": "string"
                             },
@@ -5806,25 +6965,32 @@
                         "additionalProperties": false
                       },
                       "flexVolume": {
+                        "description": "flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
                         "properties": {
                           "driver": {
+                            "description": "driver is the name of the driver to use for this volume.",
                             "type": "string"
                           },
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
                             "type": "string"
                           },
                           "options": {
                             "additionalProperties": {
                               "type": "string"
                             },
+                            "description": "options is Optional: this field holds extra command options if any.",
                             "type": "object"
                           },
                           "readOnly": {
+                            "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -5839,11 +7005,14 @@
                         "additionalProperties": false
                       },
                       "flocker": {
+                        "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
                         "properties": {
                           "datasetName": {
+                            "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
                             "type": "string"
                           },
                           "datasetUUID": {
+                            "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
                             "type": "string"
                           }
                         },
@@ -5851,18 +7020,23 @@
                         "additionalProperties": false
                       },
                       "gcePersistentDisk": {
+                        "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine",
                             "type": "string"
                           },
                           "partition": {
+                            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                             "format": "int32",
                             "type": "integer"
                           },
                           "pdName": {
+                            "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                             "type": "boolean"
                           }
                         },
@@ -5873,14 +7047,18 @@
                         "additionalProperties": false
                       },
                       "gitRepo": {
+                        "description": "gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
                         "properties": {
                           "directory": {
+                            "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
                             "type": "string"
                           },
                           "repository": {
+                            "description": "repository is the URL",
                             "type": "string"
                           },
                           "revision": {
+                            "description": "revision is the commit hash for the specified revision.",
                             "type": "string"
                           }
                         },
@@ -5891,14 +7069,18 @@
                         "additionalProperties": false
                       },
                       "glusterfs": {
+                        "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md",
                         "properties": {
                           "endpoints": {
+                            "description": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                             "type": "string"
                           },
                           "path": {
+                            "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                             "type": "boolean"
                           }
                         },
@@ -5910,11 +7092,14 @@
                         "additionalProperties": false
                       },
                       "hostPath": {
+                        "description": "hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
                         "properties": {
                           "path": {
+                            "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                             "type": "string"
                           },
                           "type": {
+                            "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                             "type": "string"
                           }
                         },
@@ -5925,41 +7110,53 @@
                         "additionalProperties": false
                       },
                       "iscsi": {
+                        "description": "iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
                         "properties": {
                           "chapAuthDiscovery": {
+                            "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
                             "type": "boolean"
                           },
                           "chapAuthSession": {
+                            "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
                             "type": "boolean"
                           },
                           "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine",
                             "type": "string"
                           },
                           "initiatorName": {
+                            "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
                             "type": "string"
                           },
                           "iqn": {
+                            "description": "iqn is the target iSCSI Qualified Name.",
                             "type": "string"
                           },
                           "iscsiInterface": {
+                            "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
                             "type": "string"
                           },
                           "lun": {
+                            "description": "lun represents iSCSI Target Lun number.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "portals": {
+                            "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -5967,6 +7164,7 @@
                             "additionalProperties": false
                           },
                           "targetPortal": {
+                            "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
                             "type": "string"
                           }
                         },
@@ -5979,17 +7177,22 @@
                         "additionalProperties": false
                       },
                       "name": {
+                        "description": "name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "nfs": {
+                        "description": "nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                         "properties": {
                           "path": {
+                            "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                             "type": "boolean"
                           },
                           "server": {
+                            "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                             "type": "string"
                           }
                         },
@@ -6001,11 +7204,14 @@
                         "additionalProperties": false
                       },
                       "persistentVolumeClaim": {
+                        "description": "persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                         "properties": {
                           "claimName": {
+                            "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly Will force the ReadOnly setting in VolumeMounts. Default false.",
                             "type": "boolean"
                           }
                         },
@@ -6016,11 +7222,14 @@
                         "additionalProperties": false
                       },
                       "photonPersistentDisk": {
+                        "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                             "type": "string"
                           },
                           "pdID": {
+                            "description": "pdID is the ID that identifies Photon Controller persistent disk",
                             "type": "string"
                           }
                         },
@@ -6031,14 +7240,18 @@
                         "additionalProperties": false
                       },
                       "portworxVolume": {
+                        "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine",
                         "properties": {
                           "fsType": {
+                            "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "volumeID": {
+                            "description": "volumeID uniquely identifies a Portworx volume",
                             "type": "string"
                           }
                         },
@@ -6049,27 +7262,37 @@
                         "additionalProperties": false
                       },
                       "projected": {
+                        "description": "projected items for all in one resources secrets, configmaps, and downward API",
                         "properties": {
                           "defaultMode": {
+                            "description": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "sources": {
+                            "description": "sources is the list of volume projections",
                             "items": {
+                              "description": "Projection that may be projected along with other supported volume types",
                               "properties": {
                                 "configMap": {
+                                  "description": "configMap information about the configMap data to project",
                                   "properties": {
                                     "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                                       "items": {
+                                        "description": "Maps a string key to a path within a volume.",
                                         "properties": {
                                           "key": {
+                                            "description": "key is the key to project.",
                                             "type": "string"
                                           },
                                           "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                             "format": "int32",
                                             "type": "integer"
                                           },
                                           "path": {
+                                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                             "type": "string"
                                           }
                                         },
@@ -6083,9 +7306,11 @@
                                       "type": "array"
                                     },
                                     "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     },
                                     "optional": {
+                                      "description": "optional specify whether the ConfigMap or its keys must be defined",
                                       "type": "boolean"
                                     }
                                   },
@@ -6093,16 +7318,22 @@
                                   "additionalProperties": false
                                 },
                                 "downwardAPI": {
+                                  "description": "downwardAPI information about the downwardAPI data to project",
                                   "properties": {
                                     "items": {
+                                      "description": "Items is a list of DownwardAPIVolume file",
                                       "items": {
+                                        "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
                                         "properties": {
                                           "fieldRef": {
+                                            "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
                                             "properties": {
                                               "apiVersion": {
+                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                                 "type": "string"
                                               },
                                               "fieldPath": {
+                                                "description": "Path of the field to select in the specified API version.",
                                                 "type": "string"
                                               }
                                             },
@@ -6113,15 +7344,19 @@
                                             "additionalProperties": false
                                           },
                                           "mode": {
+                                            "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                             "format": "int32",
                                             "type": "integer"
                                           },
                                           "path": {
+                                            "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
                                             "type": "string"
                                           },
                                           "resourceFieldRef": {
+                                            "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
                                             "properties": {
                                               "containerName": {
+                                                "description": "Container name: required for volumes, optional for env vars",
                                                 "type": "string"
                                               },
                                               "divisor": {
@@ -6133,10 +7368,12 @@
                                                     "type": "string"
                                                   }
                                                 ],
+                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                                 "x-kubernetes-int-or-string": true
                                               },
                                               "resource": {
+                                                "description": "Required: resource to select",
                                                 "type": "string"
                                               }
                                             },
@@ -6160,18 +7397,24 @@
                                   "additionalProperties": false
                                 },
                                 "secret": {
+                                  "description": "secret information about the secret data to project",
                                   "properties": {
                                     "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                                       "items": {
+                                        "description": "Maps a string key to a path within a volume.",
                                         "properties": {
                                           "key": {
+                                            "description": "key is the key to project.",
                                             "type": "string"
                                           },
                                           "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                             "format": "int32",
                                             "type": "integer"
                                           },
                                           "path": {
+                                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                             "type": "string"
                                           }
                                         },
@@ -6185,9 +7428,11 @@
                                       "type": "array"
                                     },
                                     "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     },
                                     "optional": {
+                                      "description": "optional field specify whether the Secret or its key must be defined",
                                       "type": "boolean"
                                     }
                                   },
@@ -6195,15 +7440,19 @@
                                   "additionalProperties": false
                                 },
                                 "serviceAccountToken": {
+                                  "description": "serviceAccountToken is information about the serviceAccountToken data to project",
                                   "properties": {
                                     "audience": {
+                                      "description": "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
                                       "type": "string"
                                     },
                                     "expirationSeconds": {
+                                      "description": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
                                       "format": "int64",
                                       "type": "integer"
                                     },
                                     "path": {
+                                      "description": "path is the path relative to the mount point of the file to project the token into.",
                                       "type": "string"
                                     }
                                   },
@@ -6224,23 +7473,30 @@
                         "additionalProperties": false
                       },
                       "quobyte": {
+                        "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
                         "properties": {
                           "group": {
+                            "description": "group to map volume access to Default is no group",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
                             "type": "boolean"
                           },
                           "registry": {
+                            "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
                             "type": "string"
                           },
                           "tenant": {
+                            "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
                             "type": "string"
                           },
                           "user": {
+                            "description": "user to map volume access to Defaults to serivceaccount user",
                             "type": "string"
                           },
                           "volume": {
+                            "description": "volume is a string that references an already created Quobyte volume by name.",
                             "type": "string"
                           }
                         },
@@ -6252,31 +7508,40 @@
                         "additionalProperties": false
                       },
                       "rbd": {
+                        "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine",
                             "type": "string"
                           },
                           "image": {
+                            "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "type": "string"
                           },
                           "keyring": {
+                            "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "type": "string"
                           },
                           "monitors": {
+                            "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "pool": {
+                            "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -6284,6 +7549,7 @@
                             "additionalProperties": false
                           },
                           "user": {
+                            "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "type": "string"
                           }
                         },
@@ -6295,22 +7561,29 @@
                         "additionalProperties": false
                       },
                       "scaleIO": {
+                        "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
                             "type": "string"
                           },
                           "gateway": {
+                            "description": "gateway is the host address of the ScaleIO API Gateway.",
                             "type": "string"
                           },
                           "protectionDomain": {
+                            "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -6318,18 +7591,23 @@
                             "additionalProperties": false
                           },
                           "sslEnabled": {
+                            "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
                             "type": "boolean"
                           },
                           "storageMode": {
+                            "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
                             "type": "string"
                           },
                           "storagePool": {
+                            "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
                             "type": "string"
                           },
                           "system": {
+                            "description": "system is the name of the storage system as configured in ScaleIO.",
                             "type": "string"
                           },
                           "volumeName": {
+                            "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
                             "type": "string"
                           }
                         },
@@ -6342,22 +7620,29 @@
                         "additionalProperties": false
                       },
                       "secret": {
+                        "description": "secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
                         "properties": {
                           "defaultMode": {
+                            "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "items": {
+                            "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                             "items": {
+                              "description": "Maps a string key to a path within a volume.",
                               "properties": {
                                 "key": {
+                                  "description": "key is the key to project.",
                                   "type": "string"
                                 },
                                 "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                   "format": "int32",
                                   "type": "integer"
                                 },
                                 "path": {
+                                  "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                   "type": "string"
                                 }
                               },
@@ -6371,9 +7656,11 @@
                             "type": "array"
                           },
                           "optional": {
+                            "description": "optional field specify whether the Secret or its keys must be defined",
                             "type": "boolean"
                           },
                           "secretName": {
+                            "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
                             "type": "string"
                           }
                         },
@@ -6381,16 +7668,21 @@
                         "additionalProperties": false
                       },
                       "storageos": {
+                        "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -6398,9 +7690,11 @@
                             "additionalProperties": false
                           },
                           "volumeName": {
+                            "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
                             "type": "string"
                           },
                           "volumeNamespace": {
+                            "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
                             "type": "string"
                           }
                         },
@@ -6408,17 +7702,22 @@
                         "additionalProperties": false
                       },
                       "vsphereVolume": {
+                        "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                             "type": "string"
                           },
                           "storagePolicyID": {
+                            "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
                             "type": "string"
                           },
                           "storagePolicyName": {
+                            "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
                             "type": "string"
                           },
                           "volumePath": {
+                            "description": "volumePath is the path that identifies vSphere volume vmdk",
                             "type": "string"
                           }
                         },
@@ -6446,16 +7745,21 @@
               "additionalProperties": false
             },
             "customConfig": {
+              "description": "Allow to put custom configuration for the Agent, corresponding to the datadog-cluster.yaml config file.",
               "properties": {
                 "configData": {
+                  "description": "ConfigData corresponds to the configuration file content.",
                   "type": "string"
                 },
                 "configMap": {
+                  "description": "Enable to specify a reference to an already existing ConfigMap.",
                   "properties": {
                     "fileKey": {
+                      "description": "FileKey corresponds to the key used in the ConfigMap.Data to store the configuration file content.",
                       "type": "string"
                     },
                     "name": {
+                      "description": "The name of source ConfigMap.",
                       "type": "string"
                     }
                   },
@@ -6467,26 +7771,35 @@
               "additionalProperties": false
             },
             "deploymentName": {
+              "description": "Name of the Cluster Agent Deployment to create or migrate from.",
               "type": "string"
             },
             "enabled": {
+              "description": "Enabled",
               "type": "boolean"
             },
             "image": {
+              "description": "The container image of the Datadog Cluster Agent.",
               "properties": {
                 "jmxEnabled": {
+                  "description": "Define whether the Agent image should support JMX. To be used if the Name field does not correspond to a full image string.",
                   "type": "boolean"
                 },
                 "name": {
+                  "description": "Define the image to use: Use \"gcr.io/datadoghq/agent:latest\" for Datadog Agent 7. Use \"datadog/dogstatsd:latest\" for standalone Datadog Agent DogStatsD 7. Use \"gcr.io/datadoghq/cluster-agent:latest\" for Datadog Cluster Agent. Use \"agent\" with the registry and tag configurations for <registry>/agent:<tag>. Use \"cluster-agent\" with the registry and tag configurations for <registry>/cluster-agent:<tag>. If the name is the full image string\u2014`<name>:<tag>` or `<registry>/<name>:<tag>`, then `tag`, `jmxEnabled`, and `global.registry` values are ignored. Otherwise, image string is created by overriding default settings with supplied `name`, `tag`, and `jmxEnabled` values; image string is created using default registry unless `global.registry` is configured.",
                   "type": "string"
                 },
                 "pullPolicy": {
+                  "description": "The Kubernetes pull policy: Use Always, Never, or IfNotPresent.",
                   "type": "string"
                 },
                 "pullSecrets": {
+                  "description": "It is possible to specify Docker registry credentials. See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
                   "items": {
+                    "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
                     "properties": {
                       "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                         "type": "string"
                       }
                     },
@@ -6496,6 +7809,7 @@
                   "type": "array"
                 },
                 "tag": {
+                  "description": "Define the image tag to use. To be used if the Name field does not correspond to a full image string.",
                   "type": "string"
                 }
               },
@@ -6503,29 +7817,40 @@
               "additionalProperties": false
             },
             "keepAnnotations": {
+              "description": "KeepAnnotations allows the specification of annotations not managed by the Operator that will be kept on ClusterAgent Deployment. All annotations containing 'datadoghq.com' are always included. This field uses glob syntax.",
               "type": "string"
             },
             "keepLabels": {
+              "description": "KeepLabels allows the specification of labels not managed by the Operator that will be kept on ClusterAgent Deployment. All labels containing 'datadoghq.com' are always included. This field uses glob syntax.",
               "type": "string"
             },
             "networkPolicy": {
+              "description": "Provide Cluster Agent Network Policy configuration.",
               "properties": {
                 "create": {
+                  "description": "If true, create a NetworkPolicy for the current agent.",
                   "type": "boolean"
                 },
                 "dnsSelectorEndpoints": {
+                  "description": "Cilium selector of the DNS\u202fserver entity.",
                   "items": {
+                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
                     "properties": {
                       "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                         "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                           "properties": {
                             "key": {
+                              "description": "key is the label key that the selector applies to.",
                               "type": "string"
                             },
                             "operator": {
+                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                               "type": "string"
                             },
                             "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                               "items": {
                                 "type": "string"
                               },
@@ -6545,6 +7870,7 @@
                         "additionalProperties": {
                           "type": "string"
                         },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                         "type": "object"
                       }
                     },
@@ -6555,6 +7881,7 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "flavor": {
+                  "description": "Which network policy to use. Can be `kubernetes` or `cilium`.",
                   "type": "string"
                 }
               },
@@ -6565,17 +7892,22 @@
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
               "type": "object"
             },
             "priorityClassName": {
+              "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
               "type": "string"
             },
             "rbac": {
+              "description": "RBAC configuration of the Datadog Cluster Agent.",
               "properties": {
                 "create": {
+                  "description": "Used to configure RBAC resources creation.",
                   "type": "boolean"
                 },
                 "serviceAccountName": {
+                  "description": "Used to set up the service account name to use. Ignored if the field Create is true.",
                   "type": "string"
                 }
               },
@@ -6583,26 +7915,34 @@
               "additionalProperties": false
             },
             "replicas": {
+              "description": "Number of the Cluster Agent replicas.",
               "format": "int32",
               "type": "integer"
             },
             "tolerations": {
+              "description": "If specified, the Cluster-Agent pod's tolerations.",
               "items": {
+                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
                 "properties": {
                   "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                     "type": "string"
                   },
                   "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                     "type": "string"
                   },
                   "operator": {
+                    "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
                     "type": "string"
                   },
                   "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
                     "format": "int64",
                     "type": "integer"
                   },
                   "value": {
+                    "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
                     "type": "string"
                   }
                 },
@@ -6617,38 +7957,51 @@
           "additionalProperties": false
         },
         "clusterChecksRunner": {
+          "description": "The desired state of the Cluster Checks Runner as a deployment.",
           "properties": {
             "additionalAnnotations": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "AdditionalAnnotations provide annotations that will be added to the cluster checks runner Pods.",
               "type": "object"
             },
             "additionalLabels": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "AdditionalLabels provide labels that will be added to the cluster checks runner Pods.",
               "type": "object"
             },
             "affinity": {
+              "description": "If specified, the pod's scheduling constraints.",
               "properties": {
                 "nodeAffinity": {
+                  "description": "Describes node affinity scheduling rules for the pod.",
                   "properties": {
                     "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
                       "items": {
+                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
                         "properties": {
                           "preference": {
+                            "description": "A node selector term, associated with the corresponding weight.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -6665,15 +8018,20 @@
                                 "type": "array"
                               },
                               "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -6694,6 +8052,7 @@
                             "additionalProperties": false
                           },
                           "weight": {
+                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -6708,20 +8067,28 @@
                       "type": "array"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
                       "properties": {
                         "nodeSelectorTerms": {
+                          "description": "Required. A list of node selector terms. The terms are ORed.",
                           "items": {
+                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -6738,15 +8105,20 @@
                                 "type": "array"
                               },
                               "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -6780,24 +8152,34 @@
                   "additionalProperties": false
                 },
                 "podAffinity": {
+                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
                   "properties": {
                     "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
                       "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
                         "properties": {
                           "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
                             "properties": {
                               "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -6817,6 +8199,7 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
@@ -6824,17 +8207,23 @@
                                 "additionalProperties": false
                               },
                               "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -6854,6 +8243,7 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
@@ -6861,12 +8251,14 @@
                                 "additionalProperties": false
                               },
                               "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                                 "items": {
                                   "type": "string"
                                 },
                                 "type": "array"
                               },
                               "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                 "type": "string"
                               }
                             },
@@ -6877,6 +8269,7 @@
                             "additionalProperties": false
                           },
                           "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -6891,20 +8284,28 @@
                       "type": "array"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
                       "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
                         "properties": {
                           "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -6924,6 +8325,7 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
@@ -6931,17 +8333,23 @@
                             "additionalProperties": false
                           },
                           "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -6961,6 +8369,7 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
@@ -6968,12 +8377,14 @@
                             "additionalProperties": false
                           },
                           "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                             "type": "string"
                           }
                         },
@@ -6990,24 +8401,34 @@
                   "additionalProperties": false
                 },
                 "podAntiAffinity": {
+                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
                   "properties": {
                     "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
                       "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
                         "properties": {
                           "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
                             "properties": {
                               "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -7027,6 +8448,7 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
@@ -7034,17 +8456,23 @@
                                 "additionalProperties": false
                               },
                               "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -7064,6 +8492,7 @@
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
@@ -7071,12 +8500,14 @@
                                 "additionalProperties": false
                               },
                               "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                                 "items": {
                                   "type": "string"
                                 },
                                 "type": "array"
                               },
                               "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                 "type": "string"
                               }
                             },
@@ -7087,6 +8518,7 @@
                             "additionalProperties": false
                           },
                           "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -7101,20 +8533,28 @@
                       "type": "array"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
                       "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
                         "properties": {
                           "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -7134,6 +8574,7 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
@@ -7141,17 +8582,23 @@
                             "additionalProperties": false
                           },
                           "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -7171,6 +8618,7 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
@@ -7178,12 +8626,14 @@
                             "additionalProperties": false
                           },
                           "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                             "type": "string"
                           }
                         },
@@ -7204,8 +8654,10 @@
               "additionalProperties": false
             },
             "config": {
+              "description": "Agent configuration.",
               "properties": {
                 "args": {
+                  "description": "Args allows the specification of extra args to `Command` parameter",
                   "items": {
                     "type": "string"
                   },
@@ -7213,6 +8665,7 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "command": {
+                  "description": "Command allows the specification of custom entrypoint for Cluster Checks Runner container",
                   "items": {
                     "type": "string"
                   },
@@ -7220,25 +8673,34 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "env": {
+                  "description": "The Datadog Agent supports many environment variables. See also: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables",
                   "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
                     "properties": {
                       "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                         "type": "string"
                       },
                       "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
                         "type": "string"
                       },
                       "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                         "properties": {
                           "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
                             "properties": {
                               "key": {
+                                "description": "The key to select.",
                                 "type": "string"
                               },
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -7249,11 +8711,14 @@
                             "additionalProperties": false
                           },
                           "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                             "properties": {
                               "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                 "type": "string"
                               },
                               "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
                                 "type": "string"
                               }
                             },
@@ -7264,8 +8729,10 @@
                             "additionalProperties": false
                           },
                           "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                             "properties": {
                               "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
                                 "type": "string"
                               },
                               "divisor": {
@@ -7277,10 +8744,12 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                 "x-kubernetes-int-or-string": true
                               },
                               "resource": {
+                                "description": "Required: resource to select",
                                 "type": "string"
                               }
                             },
@@ -7291,14 +8760,18 @@
                             "additionalProperties": false
                           },
                           "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
                             "properties": {
                               "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -7326,14 +8799,18 @@
                   "x-kubernetes-list-type": "map"
                 },
                 "healthPort": {
+                  "description": "HealthPort of the Agent container for internal liveness probe. Must be the same as the Liveness/Readiness probes.",
                   "format": "int32",
                   "type": "integer"
                 },
                 "livenessProbe": {
+                  "description": "Configure the Liveness Probe of the CLC container",
                   "properties": {
                     "exec": {
+                      "description": "Exec specifies the action to take.",
                       "properties": {
                         "command": {
+                          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                           "items": {
                             "type": "string"
                           },
@@ -7344,16 +8821,20 @@
                       "additionalProperties": false
                     },
                     "failureThreshold": {
+                      "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "grpc": {
+                      "description": "GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.",
                       "properties": {
                         "port": {
+                          "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "service": {
+                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
                           "type": "string"
                         }
                       },
@@ -7364,17 +8845,23 @@
                       "additionalProperties": false
                     },
                     "httpGet": {
+                      "description": "HTTPGet specifies the http request to perform.",
                       "properties": {
                         "host": {
+                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
                           "type": "string"
                         },
                         "httpHeaders": {
+                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                           "items": {
+                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                             "properties": {
                               "name": {
+                                "description": "The header field name",
                                 "type": "string"
                               },
                               "value": {
+                                "description": "The header field value",
                                 "type": "string"
                               }
                             },
@@ -7388,6 +8875,7 @@
                           "type": "array"
                         },
                         "path": {
+                          "description": "Path to access on the HTTP server.",
                           "type": "string"
                         },
                         "port": {
@@ -7399,9 +8887,11 @@
                               "type": "string"
                             }
                           ],
+                          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
                           "x-kubernetes-int-or-string": true
                         },
                         "scheme": {
+                          "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
                           "type": "string"
                         }
                       },
@@ -7412,20 +8902,25 @@
                       "additionalProperties": false
                     },
                     "initialDelaySeconds": {
+                      "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                       "format": "int32",
                       "type": "integer"
                     },
                     "periodSeconds": {
+                      "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "successThreshold": {
+                      "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "tcpSocket": {
+                      "description": "TCPSocket specifies an action involving a TCP port.",
                       "properties": {
                         "host": {
+                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
                           "type": "string"
                         },
                         "port": {
@@ -7437,6 +8932,7 @@
                               "type": "string"
                             }
                           ],
+                          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
                           "x-kubernetes-int-or-string": true
                         }
                       },
@@ -7447,10 +8943,12 @@
                       "additionalProperties": false
                     },
                     "terminationGracePeriodSeconds": {
+                      "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "timeoutSeconds": {
+                      "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                       "format": "int32",
                       "type": "integer"
                     }
@@ -7459,13 +8957,17 @@
                   "additionalProperties": false
                 },
                 "logLevel": {
+                  "description": "Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off",
                   "type": "string"
                 },
                 "readinessProbe": {
+                  "description": "Configure the Readiness Probe of the CLC container",
                   "properties": {
                     "exec": {
+                      "description": "Exec specifies the action to take.",
                       "properties": {
                         "command": {
+                          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                           "items": {
                             "type": "string"
                           },
@@ -7476,16 +8978,20 @@
                       "additionalProperties": false
                     },
                     "failureThreshold": {
+                      "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "grpc": {
+                      "description": "GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.",
                       "properties": {
                         "port": {
+                          "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "service": {
+                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
                           "type": "string"
                         }
                       },
@@ -7496,17 +9002,23 @@
                       "additionalProperties": false
                     },
                     "httpGet": {
+                      "description": "HTTPGet specifies the http request to perform.",
                       "properties": {
                         "host": {
+                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
                           "type": "string"
                         },
                         "httpHeaders": {
+                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                           "items": {
+                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                             "properties": {
                               "name": {
+                                "description": "The header field name",
                                 "type": "string"
                               },
                               "value": {
+                                "description": "The header field value",
                                 "type": "string"
                               }
                             },
@@ -7520,6 +9032,7 @@
                           "type": "array"
                         },
                         "path": {
+                          "description": "Path to access on the HTTP server.",
                           "type": "string"
                         },
                         "port": {
@@ -7531,9 +9044,11 @@
                               "type": "string"
                             }
                           ],
+                          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
                           "x-kubernetes-int-or-string": true
                         },
                         "scheme": {
+                          "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
                           "type": "string"
                         }
                       },
@@ -7544,20 +9059,25 @@
                       "additionalProperties": false
                     },
                     "initialDelaySeconds": {
+                      "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                       "format": "int32",
                       "type": "integer"
                     },
                     "periodSeconds": {
+                      "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "successThreshold": {
+                      "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "tcpSocket": {
+                      "description": "TCPSocket specifies an action involving a TCP port.",
                       "properties": {
                         "host": {
+                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
                           "type": "string"
                         },
                         "port": {
@@ -7569,6 +9089,7 @@
                               "type": "string"
                             }
                           ],
+                          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
                           "x-kubernetes-int-or-string": true
                         }
                       },
@@ -7579,10 +9100,12 @@
                       "additionalProperties": false
                     },
                     "terminationGracePeriodSeconds": {
+                      "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "timeoutSeconds": {
+                      "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                       "format": "int32",
                       "type": "integer"
                     }
@@ -7591,6 +9114,7 @@
                   "additionalProperties": false
                 },
                 "resources": {
+                  "description": "Datadog Cluster Checks Runner resource requests and limits.",
                   "properties": {
                     "limits": {
                       "additionalProperties": {
@@ -7605,6 +9129,7 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
+                      "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                       "type": "object"
                     },
                     "requests": {
@@ -7620,6 +9145,7 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
+                      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                       "type": "object"
                     }
                   },
@@ -7627,37 +9153,48 @@
                   "additionalProperties": false
                 },
                 "securityContext": {
+                  "description": "Pod-level SecurityContext.",
                   "properties": {
                     "fsGroup": {
+                      "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "fsGroupChangePolicy": {
+                      "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.",
                       "type": "string"
                     },
                     "runAsGroup": {
+                      "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "runAsNonRoot": {
+                      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
                       "type": "boolean"
                     },
                     "runAsUser": {
+                      "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "seLinuxOptions": {
+                      "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
                       "properties": {
                         "level": {
+                          "description": "Level is SELinux level label that applies to the container.",
                           "type": "string"
                         },
                         "role": {
+                          "description": "Role is a SELinux role label that applies to the container.",
                           "type": "string"
                         },
                         "type": {
+                          "description": "Type is a SELinux type label that applies to the container.",
                           "type": "string"
                         },
                         "user": {
+                          "description": "User is a SELinux user label that applies to the container.",
                           "type": "string"
                         }
                       },
@@ -7665,11 +9202,14 @@
                       "additionalProperties": false
                     },
                     "seccompProfile": {
+                      "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.",
                       "properties": {
                         "localhostProfile": {
+                          "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
                           "type": "string"
                         },
                         "type": {
+                          "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
                           "type": "string"
                         }
                       },
@@ -7680,6 +9220,7 @@
                       "additionalProperties": false
                     },
                     "supplementalGroups": {
+                      "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container. Note that this field cannot be set when spec.os.name is windows.",
                       "items": {
                         "format": "int64",
                         "type": "integer"
@@ -7687,12 +9228,16 @@
                       "type": "array"
                     },
                     "sysctls": {
+                      "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
                       "items": {
+                        "description": "Sysctl defines a kernel parameter to be set",
                         "properties": {
                           "name": {
+                            "description": "Name of a property to set",
                             "type": "string"
                           },
                           "value": {
+                            "description": "Value of a property to set",
                             "type": "string"
                           }
                         },
@@ -7706,17 +9251,22 @@
                       "type": "array"
                     },
                     "windowsOptions": {
+                      "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
                       "properties": {
                         "gmsaCredentialSpec": {
+                          "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
                           "type": "string"
                         },
                         "gmsaCredentialSpecName": {
+                          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                           "type": "string"
                         },
                         "hostProcess": {
+                          "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
                           "type": "boolean"
                         },
                         "runAsUserName": {
+                          "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
                           "type": "string"
                         }
                       },
@@ -7728,24 +9278,32 @@
                   "additionalProperties": false
                 },
                 "volumeMounts": {
+                  "description": "Specify additional volume mounts in the Datadog Cluster Check Runner container.",
                   "items": {
+                    "description": "VolumeMount describes a mounting of a Volume within a container.",
                     "properties": {
                       "mountPath": {
+                        "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
                         "type": "string"
                       },
                       "mountPropagation": {
+                        "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
                         "type": "string"
                       },
                       "name": {
+                        "description": "This must match the Name of a Volume.",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
                         "type": "boolean"
                       },
                       "subPath": {
+                        "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
                         "type": "string"
                       },
                       "subPathExpr": {
+                        "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
                         "type": "string"
                       }
                     },
@@ -7764,21 +9322,28 @@
                   "x-kubernetes-list-type": "map"
                 },
                 "volumes": {
+                  "description": "Specify additional volumes in the Datadog Cluster Check Runner container.",
                   "items": {
+                    "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
                     "properties": {
                       "awsElasticBlockStore": {
+                        "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine",
                             "type": "string"
                           },
                           "partition": {
+                            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
                             "format": "int32",
                             "type": "integer"
                           },
                           "readOnly": {
+                            "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                             "type": "boolean"
                           },
                           "volumeID": {
+                            "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                             "type": "string"
                           }
                         },
@@ -7789,23 +9354,30 @@
                         "additionalProperties": false
                       },
                       "azureDisk": {
+                        "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
                         "properties": {
                           "cachingMode": {
+                            "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
                             "type": "string"
                           },
                           "diskName": {
+                            "description": "diskName is the Name of the data disk in the blob storage",
                             "type": "string"
                           },
                           "diskURI": {
+                            "description": "diskURI is the URI of data disk in the blob storage",
                             "type": "string"
                           },
                           "fsType": {
+                            "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                             "type": "string"
                           },
                           "kind": {
+                            "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           }
                         },
@@ -7817,14 +9389,18 @@
                         "additionalProperties": false
                       },
                       "azureFile": {
+                        "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.",
                         "properties": {
                           "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "secretName": {
+                            "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
                             "type": "string"
                           },
                           "shareName": {
+                            "description": "shareName is the azure share Name",
                             "type": "string"
                           }
                         },
@@ -7836,25 +9412,32 @@
                         "additionalProperties": false
                       },
                       "cephfs": {
+                        "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
                         "properties": {
                           "monitors": {
+                            "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "path": {
+                            "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                             "type": "boolean"
                           },
                           "secretFile": {
+                            "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                             "type": "string"
                           },
                           "secretRef": {
+                            "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -7862,6 +9445,7 @@
                             "additionalProperties": false
                           },
                           "user": {
+                            "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                             "type": "string"
                           }
                         },
@@ -7872,16 +9456,21 @@
                         "additionalProperties": false
                       },
                       "cinder": {
+                        "description": "cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -7889,6 +9478,7 @@
                             "additionalProperties": false
                           },
                           "volumeID": {
+                            "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                             "type": "string"
                           }
                         },
@@ -7899,22 +9489,29 @@
                         "additionalProperties": false
                       },
                       "configMap": {
+                        "description": "configMap represents a configMap that should populate this volume",
                         "properties": {
                           "defaultMode": {
+                            "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                             "items": {
+                              "description": "Maps a string key to a path within a volume.",
                               "properties": {
                                 "key": {
+                                  "description": "key is the key to project.",
                                   "type": "string"
                                 },
                                 "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                   "format": "int32",
                                   "type": "integer"
                                 },
                                 "path": {
+                                  "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                   "type": "string"
                                 }
                               },
@@ -7928,9 +9525,11 @@
                             "type": "array"
                           },
                           "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                             "type": "string"
                           },
                           "optional": {
+                            "description": "optional specify whether the ConfigMap or its keys must be defined",
                             "type": "boolean"
                           }
                         },
@@ -7938,16 +9537,21 @@
                         "additionalProperties": false
                       },
                       "csi": {
+                        "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
                         "properties": {
                           "driver": {
+                            "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
                             "type": "string"
                           },
                           "fsType": {
+                            "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
                             "type": "string"
                           },
                           "nodePublishSecretRef": {
+                            "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -7955,12 +9559,14 @@
                             "additionalProperties": false
                           },
                           "readOnly": {
+                            "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
                             "type": "boolean"
                           },
                           "volumeAttributes": {
                             "additionalProperties": {
                               "type": "string"
                             },
+                            "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
                             "type": "object"
                           }
                         },
@@ -7971,20 +9577,27 @@
                         "additionalProperties": false
                       },
                       "downwardAPI": {
+                        "description": "downwardAPI represents downward API about the pod that should populate this volume",
                         "properties": {
                           "defaultMode": {
+                            "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "items": {
+                            "description": "Items is a list of downward API volume file",
                             "items": {
+                              "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
                               "properties": {
                                 "fieldRef": {
+                                  "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
                                   "properties": {
                                     "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                       "type": "string"
                                     },
                                     "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
                                       "type": "string"
                                     }
                                   },
@@ -7995,15 +9608,19 @@
                                   "additionalProperties": false
                                 },
                                 "mode": {
+                                  "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                   "format": "int32",
                                   "type": "integer"
                                 },
                                 "path": {
+                                  "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
                                   "type": "string"
                                 },
                                 "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
                                   "properties": {
                                     "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
                                       "type": "string"
                                     },
                                     "divisor": {
@@ -8015,10 +9632,12 @@
                                           "type": "string"
                                         }
                                       ],
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                       "x-kubernetes-int-or-string": true
                                     },
                                     "resource": {
+                                      "description": "Required: resource to select",
                                       "type": "string"
                                     }
                                   },
@@ -8042,8 +9661,10 @@
                         "additionalProperties": false
                       },
                       "emptyDir": {
+                        "description": "emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                         "properties": {
                           "medium": {
+                            "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                             "type": "string"
                           },
                           "sizeLimit": {
@@ -8055,6 +9676,7 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           }
@@ -8063,29 +9685,38 @@
                         "additionalProperties": false
                       },
                       "ephemeral": {
+                        "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
                         "properties": {
                           "volumeClaimTemplate": {
+                            "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil.",
                             "properties": {
                               "metadata": {
+                                "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
                                 "type": "object"
                               },
                               "spec": {
+                                "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
                                 "properties": {
                                   "accessModes": {
+                                    "description": "accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
                                     "items": {
                                       "type": "string"
                                     },
                                     "type": "array"
                                   },
                                   "dataSource": {
+                                    "description": "dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.",
                                     "properties": {
                                       "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
                                         "type": "string"
                                       },
                                       "kind": {
+                                        "description": "Kind is the type of resource being referenced",
                                         "type": "string"
                                       },
                                       "name": {
+                                        "description": "Name is the name of resource being referenced",
                                         "type": "string"
                                       }
                                     },
@@ -8097,14 +9728,18 @@
                                     "additionalProperties": false
                                   },
                                   "dataSourceRef": {
+                                    "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.",
                                     "properties": {
                                       "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
                                         "type": "string"
                                       },
                                       "kind": {
+                                        "description": "Kind is the type of resource being referenced",
                                         "type": "string"
                                       },
                                       "name": {
+                                        "description": "Name is the name of resource being referenced",
                                         "type": "string"
                                       }
                                     },
@@ -8116,6 +9751,7 @@
                                     "additionalProperties": false
                                   },
                                   "resources": {
+                                    "description": "resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
                                     "properties": {
                                       "limits": {
                                         "additionalProperties": {
@@ -8130,6 +9766,7 @@
                                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                           "x-kubernetes-int-or-string": true
                                         },
+                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                                         "type": "object"
                                       },
                                       "requests": {
@@ -8145,6 +9782,7 @@
                                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                           "x-kubernetes-int-or-string": true
                                         },
+                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                                         "type": "object"
                                       }
                                     },
@@ -8152,17 +9790,23 @@
                                     "additionalProperties": false
                                   },
                                   "selector": {
+                                    "description": "selector is a label query over volumes to consider for binding.",
                                     "properties": {
                                       "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                         "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                           "properties": {
                                             "key": {
+                                              "description": "key is the label key that the selector applies to.",
                                               "type": "string"
                                             },
                                             "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                               "type": "string"
                                             },
                                             "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                               "items": {
                                                 "type": "string"
                                               },
@@ -8182,6 +9826,7 @@
                                         "additionalProperties": {
                                           "type": "string"
                                         },
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                         "type": "object"
                                       }
                                     },
@@ -8189,12 +9834,15 @@
                                     "additionalProperties": false
                                   },
                                   "storageClassName": {
+                                    "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
                                     "type": "string"
                                   },
                                   "volumeMode": {
+                                    "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
                                     "type": "string"
                                   },
                                   "volumeName": {
+                                    "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
                                     "type": "string"
                                   }
                                 },
@@ -8213,24 +9861,30 @@
                         "additionalProperties": false
                       },
                       "fc": {
+                        "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine",
                             "type": "string"
                           },
                           "lun": {
+                            "description": "lun is Optional: FC target lun number",
                             "format": "int32",
                             "type": "integer"
                           },
                           "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "targetWWNs": {
+                            "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "wwids": {
+                            "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
                             "items": {
                               "type": "string"
                             },
@@ -8241,25 +9895,32 @@
                         "additionalProperties": false
                       },
                       "flexVolume": {
+                        "description": "flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
                         "properties": {
                           "driver": {
+                            "description": "driver is the name of the driver to use for this volume.",
                             "type": "string"
                           },
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
                             "type": "string"
                           },
                           "options": {
                             "additionalProperties": {
                               "type": "string"
                             },
+                            "description": "options is Optional: this field holds extra command options if any.",
                             "type": "object"
                           },
                           "readOnly": {
+                            "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -8274,11 +9935,14 @@
                         "additionalProperties": false
                       },
                       "flocker": {
+                        "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
                         "properties": {
                           "datasetName": {
+                            "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
                             "type": "string"
                           },
                           "datasetUUID": {
+                            "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
                             "type": "string"
                           }
                         },
@@ -8286,18 +9950,23 @@
                         "additionalProperties": false
                       },
                       "gcePersistentDisk": {
+                        "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine",
                             "type": "string"
                           },
                           "partition": {
+                            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                             "format": "int32",
                             "type": "integer"
                           },
                           "pdName": {
+                            "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                             "type": "boolean"
                           }
                         },
@@ -8308,14 +9977,18 @@
                         "additionalProperties": false
                       },
                       "gitRepo": {
+                        "description": "gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
                         "properties": {
                           "directory": {
+                            "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
                             "type": "string"
                           },
                           "repository": {
+                            "description": "repository is the URL",
                             "type": "string"
                           },
                           "revision": {
+                            "description": "revision is the commit hash for the specified revision.",
                             "type": "string"
                           }
                         },
@@ -8326,14 +9999,18 @@
                         "additionalProperties": false
                       },
                       "glusterfs": {
+                        "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md",
                         "properties": {
                           "endpoints": {
+                            "description": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                             "type": "string"
                           },
                           "path": {
+                            "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                             "type": "boolean"
                           }
                         },
@@ -8345,11 +10022,14 @@
                         "additionalProperties": false
                       },
                       "hostPath": {
+                        "description": "hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
                         "properties": {
                           "path": {
+                            "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                             "type": "string"
                           },
                           "type": {
+                            "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                             "type": "string"
                           }
                         },
@@ -8360,41 +10040,53 @@
                         "additionalProperties": false
                       },
                       "iscsi": {
+                        "description": "iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
                         "properties": {
                           "chapAuthDiscovery": {
+                            "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
                             "type": "boolean"
                           },
                           "chapAuthSession": {
+                            "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
                             "type": "boolean"
                           },
                           "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine",
                             "type": "string"
                           },
                           "initiatorName": {
+                            "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
                             "type": "string"
                           },
                           "iqn": {
+                            "description": "iqn is the target iSCSI Qualified Name.",
                             "type": "string"
                           },
                           "iscsiInterface": {
+                            "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
                             "type": "string"
                           },
                           "lun": {
+                            "description": "lun represents iSCSI Target Lun number.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "portals": {
+                            "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -8402,6 +10094,7 @@
                             "additionalProperties": false
                           },
                           "targetPortal": {
+                            "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
                             "type": "string"
                           }
                         },
@@ -8414,17 +10107,22 @@
                         "additionalProperties": false
                       },
                       "name": {
+                        "description": "name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "nfs": {
+                        "description": "nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                         "properties": {
                           "path": {
+                            "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                             "type": "boolean"
                           },
                           "server": {
+                            "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                             "type": "string"
                           }
                         },
@@ -8436,11 +10134,14 @@
                         "additionalProperties": false
                       },
                       "persistentVolumeClaim": {
+                        "description": "persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                         "properties": {
                           "claimName": {
+                            "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly Will force the ReadOnly setting in VolumeMounts. Default false.",
                             "type": "boolean"
                           }
                         },
@@ -8451,11 +10152,14 @@
                         "additionalProperties": false
                       },
                       "photonPersistentDisk": {
+                        "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                             "type": "string"
                           },
                           "pdID": {
+                            "description": "pdID is the ID that identifies Photon Controller persistent disk",
                             "type": "string"
                           }
                         },
@@ -8466,14 +10170,18 @@
                         "additionalProperties": false
                       },
                       "portworxVolume": {
+                        "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine",
                         "properties": {
                           "fsType": {
+                            "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "volumeID": {
+                            "description": "volumeID uniquely identifies a Portworx volume",
                             "type": "string"
                           }
                         },
@@ -8484,27 +10192,37 @@
                         "additionalProperties": false
                       },
                       "projected": {
+                        "description": "projected items for all in one resources secrets, configmaps, and downward API",
                         "properties": {
                           "defaultMode": {
+                            "description": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "sources": {
+                            "description": "sources is the list of volume projections",
                             "items": {
+                              "description": "Projection that may be projected along with other supported volume types",
                               "properties": {
                                 "configMap": {
+                                  "description": "configMap information about the configMap data to project",
                                   "properties": {
                                     "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                                       "items": {
+                                        "description": "Maps a string key to a path within a volume.",
                                         "properties": {
                                           "key": {
+                                            "description": "key is the key to project.",
                                             "type": "string"
                                           },
                                           "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                             "format": "int32",
                                             "type": "integer"
                                           },
                                           "path": {
+                                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                             "type": "string"
                                           }
                                         },
@@ -8518,9 +10236,11 @@
                                       "type": "array"
                                     },
                                     "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     },
                                     "optional": {
+                                      "description": "optional specify whether the ConfigMap or its keys must be defined",
                                       "type": "boolean"
                                     }
                                   },
@@ -8528,16 +10248,22 @@
                                   "additionalProperties": false
                                 },
                                 "downwardAPI": {
+                                  "description": "downwardAPI information about the downwardAPI data to project",
                                   "properties": {
                                     "items": {
+                                      "description": "Items is a list of DownwardAPIVolume file",
                                       "items": {
+                                        "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
                                         "properties": {
                                           "fieldRef": {
+                                            "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
                                             "properties": {
                                               "apiVersion": {
+                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                                 "type": "string"
                                               },
                                               "fieldPath": {
+                                                "description": "Path of the field to select in the specified API version.",
                                                 "type": "string"
                                               }
                                             },
@@ -8548,15 +10274,19 @@
                                             "additionalProperties": false
                                           },
                                           "mode": {
+                                            "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                             "format": "int32",
                                             "type": "integer"
                                           },
                                           "path": {
+                                            "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
                                             "type": "string"
                                           },
                                           "resourceFieldRef": {
+                                            "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
                                             "properties": {
                                               "containerName": {
+                                                "description": "Container name: required for volumes, optional for env vars",
                                                 "type": "string"
                                               },
                                               "divisor": {
@@ -8568,10 +10298,12 @@
                                                     "type": "string"
                                                   }
                                                 ],
+                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                                 "x-kubernetes-int-or-string": true
                                               },
                                               "resource": {
+                                                "description": "Required: resource to select",
                                                 "type": "string"
                                               }
                                             },
@@ -8595,18 +10327,24 @@
                                   "additionalProperties": false
                                 },
                                 "secret": {
+                                  "description": "secret information about the secret data to project",
                                   "properties": {
                                     "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                                       "items": {
+                                        "description": "Maps a string key to a path within a volume.",
                                         "properties": {
                                           "key": {
+                                            "description": "key is the key to project.",
                                             "type": "string"
                                           },
                                           "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                             "format": "int32",
                                             "type": "integer"
                                           },
                                           "path": {
+                                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                             "type": "string"
                                           }
                                         },
@@ -8620,9 +10358,11 @@
                                       "type": "array"
                                     },
                                     "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     },
                                     "optional": {
+                                      "description": "optional field specify whether the Secret or its key must be defined",
                                       "type": "boolean"
                                     }
                                   },
@@ -8630,15 +10370,19 @@
                                   "additionalProperties": false
                                 },
                                 "serviceAccountToken": {
+                                  "description": "serviceAccountToken is information about the serviceAccountToken data to project",
                                   "properties": {
                                     "audience": {
+                                      "description": "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
                                       "type": "string"
                                     },
                                     "expirationSeconds": {
+                                      "description": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
                                       "format": "int64",
                                       "type": "integer"
                                     },
                                     "path": {
+                                      "description": "path is the path relative to the mount point of the file to project the token into.",
                                       "type": "string"
                                     }
                                   },
@@ -8659,23 +10403,30 @@
                         "additionalProperties": false
                       },
                       "quobyte": {
+                        "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
                         "properties": {
                           "group": {
+                            "description": "group to map volume access to Default is no group",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
                             "type": "boolean"
                           },
                           "registry": {
+                            "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
                             "type": "string"
                           },
                           "tenant": {
+                            "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
                             "type": "string"
                           },
                           "user": {
+                            "description": "user to map volume access to Defaults to serivceaccount user",
                             "type": "string"
                           },
                           "volume": {
+                            "description": "volume is a string that references an already created Quobyte volume by name.",
                             "type": "string"
                           }
                         },
@@ -8687,31 +10438,40 @@
                         "additionalProperties": false
                       },
                       "rbd": {
+                        "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine",
                             "type": "string"
                           },
                           "image": {
+                            "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "type": "string"
                           },
                           "keyring": {
+                            "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "type": "string"
                           },
                           "monitors": {
+                            "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "pool": {
+                            "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -8719,6 +10479,7 @@
                             "additionalProperties": false
                           },
                           "user": {
+                            "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                             "type": "string"
                           }
                         },
@@ -8730,22 +10491,29 @@
                         "additionalProperties": false
                       },
                       "scaleIO": {
+                        "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
                             "type": "string"
                           },
                           "gateway": {
+                            "description": "gateway is the host address of the ScaleIO API Gateway.",
                             "type": "string"
                           },
                           "protectionDomain": {
+                            "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -8753,18 +10521,23 @@
                             "additionalProperties": false
                           },
                           "sslEnabled": {
+                            "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
                             "type": "boolean"
                           },
                           "storageMode": {
+                            "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
                             "type": "string"
                           },
                           "storagePool": {
+                            "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
                             "type": "string"
                           },
                           "system": {
+                            "description": "system is the name of the storage system as configured in ScaleIO.",
                             "type": "string"
                           },
                           "volumeName": {
+                            "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
                             "type": "string"
                           }
                         },
@@ -8777,22 +10550,29 @@
                         "additionalProperties": false
                       },
                       "secret": {
+                        "description": "secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
                         "properties": {
                           "defaultMode": {
+                            "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "items": {
+                            "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                             "items": {
+                              "description": "Maps a string key to a path within a volume.",
                               "properties": {
                                 "key": {
+                                  "description": "key is the key to project.",
                                   "type": "string"
                                 },
                                 "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                   "format": "int32",
                                   "type": "integer"
                                 },
                                 "path": {
+                                  "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                   "type": "string"
                                 }
                               },
@@ -8806,9 +10586,11 @@
                             "type": "array"
                           },
                           "optional": {
+                            "description": "optional field specify whether the Secret or its keys must be defined",
                             "type": "boolean"
                           },
                           "secretName": {
+                            "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
                             "type": "string"
                           }
                         },
@@ -8816,16 +10598,21 @@
                         "additionalProperties": false
                       },
                       "storageos": {
+                        "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                             "type": "boolean"
                           },
                           "secretRef": {
+                            "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
                             "properties": {
                               "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                 "type": "string"
                               }
                             },
@@ -8833,9 +10620,11 @@
                             "additionalProperties": false
                           },
                           "volumeName": {
+                            "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
                             "type": "string"
                           },
                           "volumeNamespace": {
+                            "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
                             "type": "string"
                           }
                         },
@@ -8843,17 +10632,22 @@
                         "additionalProperties": false
                       },
                       "vsphereVolume": {
+                        "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
                         "properties": {
                           "fsType": {
+                            "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                             "type": "string"
                           },
                           "storagePolicyID": {
+                            "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
                             "type": "string"
                           },
                           "storagePolicyName": {
+                            "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
                             "type": "string"
                           },
                           "volumePath": {
+                            "description": "volumePath is the path that identifies vSphere volume vmdk",
                             "type": "string"
                           }
                         },
@@ -8881,16 +10675,21 @@
               "additionalProperties": false
             },
             "customConfig": {
+              "description": "Allow to put custom configuration for the Agent, corresponding to the datadog.yaml config file. See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.",
               "properties": {
                 "configData": {
+                  "description": "ConfigData corresponds to the configuration file content.",
                   "type": "string"
                 },
                 "configMap": {
+                  "description": "Enable to specify a reference to an already existing ConfigMap.",
                   "properties": {
                     "fileKey": {
+                      "description": "FileKey corresponds to the key used in the ConfigMap.Data to store the configuration file content.",
                       "type": "string"
                     },
                     "name": {
+                      "description": "The name of source ConfigMap.",
                       "type": "string"
                     }
                   },
@@ -8902,26 +10701,35 @@
               "additionalProperties": false
             },
             "deploymentName": {
+              "description": "Name of the cluster checks deployment to create or migrate from.",
               "type": "string"
             },
             "enabled": {
+              "description": "Enabled",
               "type": "boolean"
             },
             "image": {
+              "description": "The container image of the Datadog Cluster Checks Runner.",
               "properties": {
                 "jmxEnabled": {
+                  "description": "Define whether the Agent image should support JMX. To be used if the Name field does not correspond to a full image string.",
                   "type": "boolean"
                 },
                 "name": {
+                  "description": "Define the image to use: Use \"gcr.io/datadoghq/agent:latest\" for Datadog Agent 7. Use \"datadog/dogstatsd:latest\" for standalone Datadog Agent DogStatsD 7. Use \"gcr.io/datadoghq/cluster-agent:latest\" for Datadog Cluster Agent. Use \"agent\" with the registry and tag configurations for <registry>/agent:<tag>. Use \"cluster-agent\" with the registry and tag configurations for <registry>/cluster-agent:<tag>. If the name is the full image string\u2014`<name>:<tag>` or `<registry>/<name>:<tag>`, then `tag`, `jmxEnabled`, and `global.registry` values are ignored. Otherwise, image string is created by overriding default settings with supplied `name`, `tag`, and `jmxEnabled` values; image string is created using default registry unless `global.registry` is configured.",
                   "type": "string"
                 },
                 "pullPolicy": {
+                  "description": "The Kubernetes pull policy: Use Always, Never, or IfNotPresent.",
                   "type": "string"
                 },
                 "pullSecrets": {
+                  "description": "It is possible to specify Docker registry credentials. See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
                   "items": {
+                    "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
                     "properties": {
                       "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                         "type": "string"
                       }
                     },
@@ -8931,6 +10739,7 @@
                   "type": "array"
                 },
                 "tag": {
+                  "description": "Define the image tag to use. To be used if the Name field does not correspond to a full image string.",
                   "type": "string"
                 }
               },
@@ -8938,23 +10747,32 @@
               "additionalProperties": false
             },
             "networkPolicy": {
+              "description": "Provide Cluster Checks Runner Network Policy configuration.",
               "properties": {
                 "create": {
+                  "description": "If true, create a NetworkPolicy for the current agent.",
                   "type": "boolean"
                 },
                 "dnsSelectorEndpoints": {
+                  "description": "Cilium selector of the DNS\u202fserver entity.",
                   "items": {
+                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
                     "properties": {
                       "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                         "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                           "properties": {
                             "key": {
+                              "description": "key is the label key that the selector applies to.",
                               "type": "string"
                             },
                             "operator": {
+                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                               "type": "string"
                             },
                             "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                               "items": {
                                 "type": "string"
                               },
@@ -8974,6 +10792,7 @@
                         "additionalProperties": {
                           "type": "string"
                         },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                         "type": "object"
                       }
                     },
@@ -8984,6 +10803,7 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "flavor": {
+                  "description": "Which network policy to use. Can be `kubernetes` or `cilium`.",
                   "type": "string"
                 }
               },
@@ -8994,17 +10814,22 @@
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
               "type": "object"
             },
             "priorityClassName": {
+              "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
               "type": "string"
             },
             "rbac": {
+              "description": "RBAC configuration of the Datadog Cluster Checks Runner.",
               "properties": {
                 "create": {
+                  "description": "Used to configure RBAC resources creation.",
                   "type": "boolean"
                 },
                 "serviceAccountName": {
+                  "description": "Used to set up the service account name to use. Ignored if the field Create is true.",
                   "type": "string"
                 }
               },
@@ -9012,26 +10837,34 @@
               "additionalProperties": false
             },
             "replicas": {
+              "description": "Number of the Cluster Checks Runner replicas.",
               "format": "int32",
               "type": "integer"
             },
             "tolerations": {
+              "description": "If specified, the Cluster-Checks pod's tolerations.",
               "items": {
+                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
                 "properties": {
                   "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                     "type": "string"
                   },
                   "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                     "type": "string"
                   },
                   "operator": {
+                    "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
                     "type": "string"
                   },
                   "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
                     "format": "int64",
                     "type": "integer"
                   },
                   "value": {
+                    "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
                     "type": "string"
                   }
                 },
@@ -9046,22 +10879,29 @@
           "additionalProperties": false
         },
         "clusterName": {
+          "description": "Set a unique cluster name to allow scoping hosts and Cluster Checks Runner easily.",
           "type": "string"
         },
         "credentials": {
+          "description": "Configure the credentials needed to run Agents. If not set, then the credentials set in the DatadogOperator will be used.",
           "properties": {
             "apiKey": {
+              "description": "APIKey Set this to your Datadog API key before the Agent runs. See also: https://app.datadoghq.com/account/settings#agent/kubernetes",
               "type": "string"
             },
             "apiKeyExistingSecret": {
+              "description": "APIKeyExistingSecret is DEPRECATED. In order to pass the API key through an existing secret, please consider \"apiSecret\" instead. If set, this parameter takes precedence over \"apiKey\".",
               "type": "string"
             },
             "apiSecret": {
+              "description": "APISecret Use existing Secret which stores API key instead of creating a new one. If set, this parameter takes precedence over \"apiKey\" and \"apiKeyExistingSecret\".",
               "properties": {
                 "keyName": {
+                  "description": "KeyName is the key of the secret to use.",
                   "type": "string"
                 },
                 "secretName": {
+                  "description": "SecretName is the name of the secret.",
                   "type": "string"
                 }
               },
@@ -9072,17 +10912,22 @@
               "additionalProperties": false
             },
             "appKey": {
+              "description": "If you are using clusterAgent.metricsProvider.enabled = true, you must set a Datadog application key for read access to your metrics.",
               "type": "string"
             },
             "appKeyExistingSecret": {
+              "description": "AppKeyExistingSecret is DEPRECATED. In order to pass the APP key through an existing secret, please consider \"appSecret\" instead. If set, this parameter takes precedence over \"appKey\".",
               "type": "string"
             },
             "appSecret": {
+              "description": "APPSecret Use existing Secret which stores API key instead of creating a new one. If set, this parameter takes precedence over \"apiKey\" and \"appKeyExistingSecret\".",
               "properties": {
                 "keyName": {
+                  "description": "KeyName is the key of the secret to use.",
                   "type": "string"
                 },
                 "secretName": {
+                  "description": "SecretName is the name of the secret.",
                   "type": "string"
                 }
               },
@@ -9093,9 +10938,11 @@
               "additionalProperties": false
             },
             "token": {
+              "description": "This needs to be at least 32 characters a-zA-z. It is a preshared key between the node agents and the cluster agent.",
               "type": "string"
             },
             "useSecretBackend": {
+              "description": "UseSecretBackend use the Agent secret backend feature for retreiving all credentials needed by the different components: Agent, Cluster, Cluster-Checks. default value is false.",
               "type": "boolean"
             }
           },
@@ -9103,23 +10950,31 @@
           "additionalProperties": false
         },
         "features": {
+          "description": "Features running on the Agent and Cluster Agent.",
           "properties": {
             "kubeStateMetricsCore": {
+              "description": "KubeStateMetricsCore configuration.",
               "properties": {
                 "clusterCheck": {
+                  "description": "ClusterCheck configures the Kubernetes State Metrics Core check as a cluster check.",
                   "type": "boolean"
                 },
                 "conf": {
+                  "description": "To override the configuration for the default Kubernetes State Metrics Core check. Must point to a ConfigMap containing a valid cluster check configuration.",
                   "properties": {
                     "configData": {
+                      "description": "ConfigData corresponds to the configuration file content.",
                       "type": "string"
                     },
                     "configMap": {
+                      "description": "Enable to specify a reference to an already existing ConfigMap.",
                       "properties": {
                         "fileKey": {
+                          "description": "FileKey corresponds to the key used in the ConfigMap.Data to store the configuration file content.",
                           "type": "string"
                         },
                         "name": {
+                          "description": "The name of source ConfigMap.",
                           "type": "string"
                         }
                       },
@@ -9131,6 +10986,7 @@
                   "additionalProperties": false
                 },
                 "enabled": {
+                  "description": "Enable this to start the Kubernetes State Metrics Core check. Refer to https://docs.datadoghq.com/integrations/kubernetes_state_core",
                   "type": "boolean"
                 }
               },
@@ -9138,30 +10994,39 @@
               "additionalProperties": false
             },
             "logCollection": {
+              "description": "LogCollection configuration.",
               "properties": {
                 "containerCollectUsingFiles": {
+                  "description": "Collect logs from files in `/var/log/pods instead` of using the container runtime API. Collecting logs from files is usually the most efficient way of collecting logs. See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup Default is true",
                   "type": "boolean"
                 },
                 "containerLogsPath": {
+                  "description": "Allows log collection from the container log path. Set to a different path if you are not using the Docker runtime. See also: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#create-manifest Defaults to `/var/lib/docker/containers`",
                   "type": "string"
                 },
                 "containerSymlinksPath": {
+                  "description": "Allows the log collection to use symbolic links in this directory to validate container ID -> pod. Defaults to `/var/log/containers`",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "Enable this option to activate Datadog Agent log collection. See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup",
                   "type": "boolean"
                 },
                 "logsConfigContainerCollectAll": {
+                  "description": "Enable this option to allow log collection for all containers. See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup",
                   "type": "boolean"
                 },
                 "openFilesLimit": {
+                  "description": "Sets the maximum number of log files that the Datadog Agent tails. Increasing this limit can increase resource consumption of the Agent. See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup Default is 100",
                   "format": "int32",
                   "type": "integer"
                 },
                 "podLogsPath": {
+                  "description": "Allows log collection from pod log path. Defaults to `/var/log/pods`.",
                   "type": "string"
                 },
                 "tempStoragePath": {
+                  "description": "This path (always mounted from the host) is used by Datadog Agent to store information about processed log files. If the Datadog Agent is restarted, it starts tailing the log files immediately. Default to `/var/lib/datadog-agent/logs`",
                   "type": "string"
                 }
               },
@@ -9169,6 +11034,7 @@
               "additionalProperties": false
             },
             "networkMonitoring": {
+              "description": "NetworkMonitoring configuration.",
               "properties": {
                 "enabled": {
                   "type": "boolean"
@@ -9178,24 +11044,32 @@
               "additionalProperties": false
             },
             "orchestratorExplorer": {
+              "description": "OrchestratorExplorer configuration.",
               "properties": {
                 "additionalEndpoints": {
+                  "description": "Additional endpoints for shipping the collected data as json in the form of {\"https://process.agent.datadoghq.com\": [\"apikey1\", ...], ...}'.",
                   "type": "string"
                 },
                 "clusterCheck": {
+                  "description": "ClusterCheck configures the Orchestrator Explorer check as a cluster check.",
                   "type": "boolean"
                 },
                 "conf": {
+                  "description": "To override the configuration for the default Orchestrator Explorer check. Must point to a ConfigMap containing a valid cluster check configuration.",
                   "properties": {
                     "configData": {
+                      "description": "ConfigData corresponds to the configuration file content.",
                       "type": "string"
                     },
                     "configMap": {
+                      "description": "Enable to specify a reference to an already existing ConfigMap.",
                       "properties": {
                         "fileKey": {
+                          "description": "FileKey corresponds to the key used in the ConfigMap.Data to store the configuration file content.",
                           "type": "string"
                         },
                         "name": {
+                          "description": "The name of source ConfigMap.",
                           "type": "string"
                         }
                       },
@@ -9207,12 +11081,15 @@
                   "additionalProperties": false
                 },
                 "ddUrl": {
+                  "description": "Set this for the Datadog endpoint for the orchestrator explorer",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "Enable this to activate live Kubernetes monitoring. See also: https://docs.datadoghq.com/infrastructure/livecontainers/#kubernetes-resources",
                   "type": "boolean"
                 },
                 "extraTags": {
+                  "description": "Additional tags for the collected data in the form of `a b c` Difference to DD_TAGS: this is a cluster agent option that is used to define custom cluster tags",
                   "items": {
                     "type": "string"
                   },
@@ -9220,8 +11097,10 @@
                   "x-kubernetes-list-type": "set"
                 },
                 "scrubbing": {
+                  "description": "Option to disable scrubbing of sensitive container data (passwords, tokens, etc. ).",
                   "properties": {
                     "containers": {
+                      "description": "Deactivate this to stop the scrubbing of sensitive container data (passwords, tokens, etc. ).",
                       "type": "boolean"
                     }
                   },
@@ -9233,14 +11112,18 @@
               "additionalProperties": false
             },
             "prometheusScrape": {
+              "description": "PrometheusScrape configuration.",
               "properties": {
                 "additionalConfigs": {
+                  "description": "AdditionalConfigs allows adding advanced prometheus check configurations with custom discovery rules.",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "Enable autodiscovering pods and services exposing prometheus metrics.",
                   "type": "boolean"
                 },
                 "serviceEndpoints": {
+                  "description": "ServiceEndpoints enables generating dedicated checks for service endpoints.",
                   "type": "boolean"
                 }
               },
@@ -9252,9 +11135,11 @@
           "additionalProperties": false
         },
         "registry": {
+          "description": "Registry to use for all Agent images (default gcr.io/datadoghq). Use public.ecr.aws/datadog for AWS Use docker.io/datadog for DockerHub",
           "type": "string"
         },
         "site": {
+          "description": "The site of the Datadog intake to send Agent data to. Set to 'datadoghq.eu' to send data to the EU site.",
           "type": "string"
         }
       },
@@ -9262,42 +11147,54 @@
       "additionalProperties": false
     },
     "status": {
+      "description": "DatadogAgentStatus defines the observed state of DatadogAgent.",
       "properties": {
         "agent": {
+          "description": "The actual state of the Agent as an extended daemonset.",
           "properties": {
             "available": {
+              "description": "Number of available pods in the DaemonSet.",
               "format": "int32",
               "type": "integer"
             },
             "current": {
+              "description": "Number of current pods in the DaemonSet.",
               "format": "int32",
               "type": "integer"
             },
             "currentHash": {
+              "description": "CurrentHash is the stored hash of the DaemonSet.",
               "type": "string"
             },
             "daemonsetName": {
+              "description": "DaemonsetName corresponds to the name of the created DaemonSet.",
               "type": "string"
             },
             "desired": {
+              "description": "Number of desired pods in the DaemonSet.",
               "format": "int32",
               "type": "integer"
             },
             "lastUpdate": {
+              "description": "LastUpdate is the last time the status was updated.",
               "format": "date-time",
               "type": "string"
             },
             "ready": {
+              "description": "Number of ready pods in the DaemonSet.",
               "format": "int32",
               "type": "integer"
             },
             "state": {
+              "description": "State corresponds to the DaemonSet state.",
               "type": "string"
             },
             "status": {
+              "description": "Status corresponds to the DaemonSet computed status.",
               "type": "string"
             },
             "upToDate": {
+              "description": "Number of up to date pods in the DaemonSet.",
               "format": "int32",
               "type": "integer"
             }
@@ -9313,43 +11210,55 @@
           "additionalProperties": false
         },
         "clusterAgent": {
+          "description": "The actual state of the Cluster Agent as a deployment.",
           "properties": {
             "availableReplicas": {
+              "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this Deployment.",
               "format": "int32",
               "type": "integer"
             },
             "currentHash": {
+              "description": "CurrentHash is the stored hash of the Deployment.",
               "type": "string"
             },
             "deploymentName": {
+              "description": "DeploymentName corresponds to the name of the Deployment.",
               "type": "string"
             },
             "generatedToken": {
+              "description": "GeneratedToken corresponds to the generated token if any token was provided in the Credential configuration when ClusterAgent is enabled.",
               "type": "string"
             },
             "lastUpdate": {
+              "description": "LastUpdate is the last time the status was updated.",
               "format": "date-time",
               "type": "string"
             },
             "readyReplicas": {
+              "description": "Total number of ready pods targeted by this Deployment.",
               "format": "int32",
               "type": "integer"
             },
             "replicas": {
+              "description": "Total number of non-terminated pods targeted by this Deployment (their labels match the selector).",
               "format": "int32",
               "type": "integer"
             },
             "state": {
+              "description": "State corresponds to the Deployment state.",
               "type": "string"
             },
             "status": {
+              "description": "Status corresponds to the Deployment computed status.",
               "type": "string"
             },
             "unavailableReplicas": {
+              "description": "Total number of unavailable pods targeted by this Deployment. This is the total number of pods that are still required for the Deployment to have 100% available capacity. They may either be pods that are running but not yet available or pods that still have not been created.",
               "format": "int32",
               "type": "integer"
             },
             "updatedReplicas": {
+              "description": "Total number of non-terminated pods targeted by this Deployment that have the desired template spec.",
               "format": "int32",
               "type": "integer"
             }
@@ -9358,43 +11267,55 @@
           "additionalProperties": false
         },
         "clusterChecksRunner": {
+          "description": "The actual state of the Cluster Checks Runner as a deployment.",
           "properties": {
             "availableReplicas": {
+              "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this Deployment.",
               "format": "int32",
               "type": "integer"
             },
             "currentHash": {
+              "description": "CurrentHash is the stored hash of the Deployment.",
               "type": "string"
             },
             "deploymentName": {
+              "description": "DeploymentName corresponds to the name of the Deployment.",
               "type": "string"
             },
             "generatedToken": {
+              "description": "GeneratedToken corresponds to the generated token if any token was provided in the Credential configuration when ClusterAgent is enabled.",
               "type": "string"
             },
             "lastUpdate": {
+              "description": "LastUpdate is the last time the status was updated.",
               "format": "date-time",
               "type": "string"
             },
             "readyReplicas": {
+              "description": "Total number of ready pods targeted by this Deployment.",
               "format": "int32",
               "type": "integer"
             },
             "replicas": {
+              "description": "Total number of non-terminated pods targeted by this Deployment (their labels match the selector).",
               "format": "int32",
               "type": "integer"
             },
             "state": {
+              "description": "State corresponds to the Deployment state.",
               "type": "string"
             },
             "status": {
+              "description": "Status corresponds to the Deployment computed status.",
               "type": "string"
             },
             "unavailableReplicas": {
+              "description": "Total number of unavailable pods targeted by this Deployment. This is the total number of pods that are still required for the Deployment to have 100% available capacity. They may either be pods that are running but not yet available or pods that still have not been created.",
               "format": "int32",
               "type": "integer"
             },
             "updatedReplicas": {
+              "description": "Total number of non-terminated pods targeted by this Deployment that have the desired template spec.",
               "format": "int32",
               "type": "integer"
             }
@@ -9403,26 +11324,34 @@
           "additionalProperties": false
         },
         "conditions": {
+          "description": "Conditions Represents the latest available observations of a DatadogAgent's current state.",
           "items": {
+            "description": "DatadogAgentCondition describes the state of a DatadogAgent at a certain point.",
             "properties": {
               "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
                 "format": "date-time",
                 "type": "string"
               },
               "lastUpdateTime": {
+                "description": "Last time the condition was updated.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
+                "description": "A human readable message indicating details about the transition.",
                 "type": "string"
               },
               "reason": {
+                "description": "The reason for the condition's last transition.",
                 "type": "string"
               },
               "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
                 "type": "string"
               },
               "type": {
+                "description": "Type of DatadogAgent condition.",
                 "type": "string"
               }
             },
@@ -9438,10 +11367,6 @@
             "type"
           ],
           "x-kubernetes-list-type": "map"
-        },
-        "defaultOverride": {
-          "type": "object",
-          "x-kubernetes-preserve-unknown-fields": true
         }
       },
       "type": "object",

--- a/datadoghq.com/datadogagent_v2alpha1.json
+++ b/datadoghq.com/datadogagent_v2alpha1.json
@@ -1,33 +1,48 @@
 {
+  "description": "DatadogAgent Deployment with the Datadog Operator.",
   "properties": {
     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
+      "description": "DatadogAgentSpec defines the desired state of DatadogAgent",
       "properties": {
         "features": {
+          "description": "Features running on the Agent and Cluster Agent",
           "properties": {
             "admissionController": {
+              "description": "AdmissionController configuration.",
               "properties": {
                 "agentCommunicationMode": {
+                  "description": "AgentCommunicationMode corresponds to the mode used by the Datadog application libraries to communicate with the Agent. It can be \"hostip\", \"service\", or \"socket\".",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "Enabled enables the Admission Controller. Default: true",
                   "type": "boolean"
                 },
                 "failurePolicy": {
+                  "description": "FailurePolicy determines how unrecognized and timeout errors are handled.",
                   "type": "string"
                 },
                 "mutateUnlabelled": {
+                  "description": "MutateUnlabelled enables config injection without the need of pod label 'admission.datadoghq.com/enabled=\"true\"'. Default: false",
                   "type": "boolean"
                 },
                 "serviceName": {
+                  "description": "ServiceName corresponds to the webhook service name.",
+                  "type": "string"
+                },
+                "webhookName": {
+                  "description": "WebhookName is a custom name for the MutatingWebhookConfiguration. Default: \"datadog-webhook\"",
                   "type": "string"
                 }
               },
@@ -35,16 +50,21 @@
               "additionalProperties": false
             },
             "apm": {
+              "description": "APM (Application Performance Monitoring) configuration.",
               "properties": {
                 "enabled": {
+                  "description": "Enabled enables Application Performance Monitoring. Default: true",
                   "type": "boolean"
                 },
                 "hostPortConfig": {
+                  "description": "HostPortConfig contains host port configuration. Enabled Default: false Port Default: 8126",
                   "properties": {
                     "enabled": {
+                      "description": "Enabled enables host port configuration Default: false",
                       "type": "boolean"
                     },
                     "hostPort": {
+                      "description": "Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.) If HostNetwork is enabled, this value must match the ContainerPort.",
                       "format": "int32",
                       "type": "integer"
                     }
@@ -52,12 +72,49 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "instrumentation": {
+                  "description": "SingleStepInstrumentation allows the agent to inject the Datadog APM libraries into all pods in the cluster. Feature is in beta. See also: https://docs.datadoghq.com/tracing/trace_collection/single-step-apm Enabled Default: false",
+                  "properties": {
+                    "disabledNamespaces": {
+                      "description": "DisabledNamespaces disables injecting the Datadog APM libraries into pods in specific namespaces.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "enabled": {
+                      "description": "Enabled enables injecting the Datadog APM libraries into all pods in the cluster. Default: false",
+                      "type": "boolean"
+                    },
+                    "enabledNamespaces": {
+                      "description": "EnabledNamespaces enables injecting the Datadog APM libraries into pods in specific namespaces.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "libVersions": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "LibVersions configures injection of specific tracing library versions with Single Step Instrumentation. <Library>: <Version> ex: \"java\": \"v1.18.0\"",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "unixDomainSocketConfig": {
+                  "description": "UnixDomainSocketConfig contains socket configuration. See also: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables Enabled Default: true Path Default: `/var/run/datadog/apm.socket`",
                   "properties": {
                     "enabled": {
+                      "description": "Enabled enables Unix Domain Socket. Default: true",
                       "type": "boolean"
                     },
                     "path": {
+                      "description": "Path defines the socket path used when enabled.",
                       "type": "string"
                     }
                   },
@@ -69,11 +126,14 @@
               "additionalProperties": false
             },
             "clusterChecks": {
+              "description": "ClusterChecks configuration.",
               "properties": {
                 "enabled": {
+                  "description": "Enables Cluster Checks scheduling in the Cluster Agent. Default: true",
                   "type": "boolean"
                 },
                 "useClusterChecksRunners": {
+                  "description": "Enabled enables Cluster Checks Runners to run all Cluster Checks. Default: false",
                   "type": "boolean"
                 }
               },
@@ -81,28 +141,38 @@
               "additionalProperties": false
             },
             "cspm": {
+              "description": "CSPM (Cloud Security Posture Management) configuration.",
               "properties": {
                 "checkInterval": {
+                  "description": "CheckInterval defines the check interval.",
                   "type": "string"
                 },
                 "customBenchmarks": {
+                  "description": "CustomBenchmarks contains CSPM benchmarks. The content of the ConfigMap will be merged with the benchmarks bundled with the agent. Any benchmarks with the same name as those existing in the agent will take precedence.",
                   "properties": {
                     "configData": {
+                      "description": "ConfigData corresponds to the configuration file content.",
                       "type": "string"
                     },
                     "configMap": {
+                      "description": "ConfigMap references an existing ConfigMap with the configuration file content.",
                       "properties": {
                         "items": {
+                          "description": "Items maps a ConfigMap data `key` to a file `path` mount.",
                           "items": {
+                            "description": "Maps a string key to a path within a volume.",
                             "properties": {
                               "key": {
+                                "description": "key is the key to project.",
                                 "type": "string"
                               },
                               "mode": {
+                                "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                 "format": "int32",
                                 "type": "integer"
                               },
                               "path": {
+                                "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                 "type": "string"
                               }
                             },
@@ -120,6 +190,7 @@
                           "x-kubernetes-list-type": "map"
                         },
                         "name": {
+                          "description": "Name is the name of the ConfigMap.",
                           "type": "string"
                         }
                       },
@@ -131,32 +202,53 @@
                   "additionalProperties": false
                 },
                 "enabled": {
+                  "description": "Enabled enables Cloud Security Posture Management. Default: false",
                   "type": "boolean"
+                },
+                "hostBenchmarks": {
+                  "description": "HostBenchmarks contains configuration for host benchmarks.",
+                  "properties": {
+                    "enabled": {
+                      "description": "Enabled enables host benchmarks. Default: false",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
               "type": "object",
               "additionalProperties": false
             },
             "cws": {
+              "description": "CWS (Cloud Workload Security) configuration.",
               "properties": {
                 "customPolicies": {
+                  "description": "CustomPolicies contains security policies. The content of the ConfigMap will be merged with the policies bundled with the agent. Any policies with the same name as those existing in the agent will take precedence.",
                   "properties": {
                     "configData": {
+                      "description": "ConfigData corresponds to the configuration file content.",
                       "type": "string"
                     },
                     "configMap": {
+                      "description": "ConfigMap references an existing ConfigMap with the configuration file content.",
                       "properties": {
                         "items": {
+                          "description": "Items maps a ConfigMap data `key` to a file `path` mount.",
                           "items": {
+                            "description": "Maps a string key to a path within a volume.",
                             "properties": {
                               "key": {
+                                "description": "key is the key to project.",
                                 "type": "string"
                               },
                               "mode": {
+                                "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                 "format": "int32",
                                 "type": "integer"
                               },
                               "path": {
+                                "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                 "type": "string"
                               }
                             },
@@ -174,6 +266,7 @@
                           "x-kubernetes-list-type": "map"
                         },
                         "name": {
+                          "description": "Name is the name of the ConfigMap.",
                           "type": "string"
                         }
                       },
@@ -185,9 +278,41 @@
                   "additionalProperties": false
                 },
                 "enabled": {
+                  "description": "Enabled enables Cloud Workload Security. Default: false",
                   "type": "boolean"
                 },
+                "network": {
+                  "properties": {
+                    "enabled": {
+                      "description": "Enabled enables Cloud Workload Security Network detections. Default: true",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "remoteConfiguration": {
+                  "properties": {
+                    "enabled": {
+                      "description": "Enabled enables Remote Configuration for Cloud Workload Security. Default: true",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "securityProfiles": {
+                  "properties": {
+                    "enabled": {
+                      "description": "Enabled enables Security Profiles collection for Cloud Workload Security. Default: true",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "syscallMonitorEnabled": {
+                  "description": "SyscallMonitorEnabled enables Syscall Monitoring (recommended for troubleshooting only). Default: false",
                   "type": "boolean"
                 }
               },
@@ -195,13 +320,17 @@
               "additionalProperties": false
             },
             "dogstatsd": {
+              "description": "Dogstatsd configuration.",
               "properties": {
                 "hostPortConfig": {
+                  "description": "HostPortConfig contains host port configuration. Enabled Default: false Port Default: 8125",
                   "properties": {
                     "enabled": {
+                      "description": "Enabled enables host port configuration Default: false",
                       "type": "boolean"
                     },
                     "hostPort": {
+                      "description": "Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.) If HostNetwork is enabled, this value must match the ContainerPort.",
                       "format": "int32",
                       "type": "integer"
                     }
@@ -210,23 +339,31 @@
                   "additionalProperties": false
                 },
                 "mapperProfiles": {
+                  "description": "Configure the Dogstasd Mapper Profiles. Can be passed as raw data or via a json encoded string in a config map. See also: https://docs.datadoghq.com/developers/dogstatsd/dogstatsd_mapper/",
                   "properties": {
                     "configData": {
+                      "description": "ConfigData corresponds to the configuration file content.",
                       "type": "string"
                     },
                     "configMap": {
+                      "description": "ConfigMap references an existing ConfigMap with the configuration file content.",
                       "properties": {
                         "items": {
+                          "description": "Items maps a ConfigMap data `key` to a file `path` mount.",
                           "items": {
+                            "description": "Maps a string key to a path within a volume.",
                             "properties": {
                               "key": {
+                                "description": "key is the key to project.",
                                 "type": "string"
                               },
                               "mode": {
+                                "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                 "format": "int32",
                                 "type": "integer"
                               },
                               "path": {
+                                "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                 "type": "string"
                               }
                             },
@@ -244,6 +381,7 @@
                           "x-kubernetes-list-type": "map"
                         },
                         "name": {
+                          "description": "Name is the name of the ConfigMap.",
                           "type": "string"
                         }
                       },
@@ -255,14 +393,22 @@
                   "additionalProperties": false
                 },
                 "originDetectionEnabled": {
+                  "description": "OriginDetectionEnabled enables origin detection for container tagging. See also: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging",
                   "type": "boolean"
                 },
+                "tagCardinality": {
+                  "description": "TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`). See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables Cardinality default: low",
+                  "type": "string"
+                },
                 "unixDomainSocketConfig": {
+                  "description": "UnixDomainSocketConfig contains socket configuration. See also: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables Enabled Default: true Path Default: `/var/run/datadog/dsd.socket`",
                   "properties": {
                     "enabled": {
+                      "description": "Enabled enables Unix Domain Socket. Default: true",
                       "type": "boolean"
                     },
                     "path": {
+                      "description": "Path defines the socket path used when enabled.",
                       "type": "string"
                     }
                   },
@@ -273,9 +419,22 @@
               "type": "object",
               "additionalProperties": false
             },
+            "ebpfCheck": {
+              "description": "EBPFCheck configuration.",
+              "properties": {
+                "enabled": {
+                  "description": "Enables the eBPF check. Default: false",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "eventCollection": {
+              "description": "EventCollection configuration.",
               "properties": {
                 "collectKubernetesEvents": {
+                  "description": "CollectKubernetesEvents enables Kubernetes event collection. Default: true",
                   "type": "boolean"
                 }
               },
@@ -283,23 +442,31 @@
               "additionalProperties": false
             },
             "externalMetricsServer": {
+              "description": "ExternalMetricsServer configuration.",
               "properties": {
                 "enabled": {
+                  "description": "Enabled enables the External Metrics Server. Default: false",
                   "type": "boolean"
                 },
                 "endpoint": {
+                  "description": "Override the API endpoint for the External Metrics Server. URL Default: \"https://app.datadoghq.com\".",
                   "properties": {
                     "credentials": {
+                      "description": "Credentials defines the Datadog credentials used to submit data to/query data from Datadog.",
                       "properties": {
                         "apiKey": {
+                          "description": "APIKey configures your Datadog API key. See also: https://app.datadoghq.com/account/settings#agent/kubernetes",
                           "type": "string"
                         },
                         "apiSecret": {
+                          "description": "APISecret references an existing Secret which stores the API key instead of creating a new one. If set, this parameter takes precedence over \"APIKey\".",
                           "properties": {
                             "keyName": {
+                              "description": "KeyName is the key of the secret to use.",
                               "type": "string"
                             },
                             "secretName": {
+                              "description": "SecretName is the name of the secret.",
                               "type": "string"
                             }
                           },
@@ -310,14 +477,18 @@
                           "additionalProperties": false
                         },
                         "appKey": {
+                          "description": "AppKey configures your Datadog application key. If you are using features.externalMetricsServer.enabled = true, you must set a Datadog application key for read access to your metrics.",
                           "type": "string"
                         },
                         "appSecret": {
+                          "description": "AppSecret references an existing Secret which stores the application key instead of creating a new one. If set, this parameter takes precedence over \"AppKey\".",
                           "properties": {
                             "keyName": {
+                              "description": "KeyName is the key of the secret to use.",
                               "type": "string"
                             },
                             "secretName": {
+                              "description": "SecretName is the name of the secret.",
                               "type": "string"
                             }
                           },
@@ -332,6 +503,7 @@
                       "additionalProperties": false
                     },
                     "url": {
+                      "description": "URL defines the endpoint URL.",
                       "type": "string"
                     }
                   },
@@ -339,39 +511,77 @@
                   "additionalProperties": false
                 },
                 "port": {
+                  "description": "Port specifies the metricsProvider External Metrics Server service port. Default: 8443",
                   "format": "int32",
                   "type": "integer"
                 },
+                "registerAPIService": {
+                  "description": "RegisterAPIService registers the External Metrics endpoint as an APIService Default: true",
+                  "type": "boolean"
+                },
                 "useDatadogMetrics": {
+                  "description": "UseDatadogMetrics enables usage of the DatadogMetrics CRD (allowing one to scale on arbitrary Datadog metric queries). Default: true",
                   "type": "boolean"
                 },
                 "wpaController": {
+                  "description": "WPAController enables the informer and controller of the Watermark Pod Autoscaler. NOTE: The Watermark Pod Autoscaler controller needs to be installed. See also: https://github.com/DataDog/watermarkpodautoscaler. Default: false",
                   "type": "boolean"
                 }
               },
               "type": "object",
               "additionalProperties": false
             },
+            "helmCheck": {
+              "description": "HelmCheck configuration.",
+              "properties": {
+                "collectEvents": {
+                  "description": "CollectEvents set to `true` enables event collection in the Helm check (Requires Agent 7.36.0+ and Cluster Agent 1.20.0+) Default: false",
+                  "type": "boolean"
+                },
+                "enabled": {
+                  "description": "Enabled enables the Helm check. Default: false",
+                  "type": "boolean"
+                },
+                "valuesAsTags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ValuesAsTags collects Helm values from a release and uses them as tags (Requires Agent and Cluster Agent 7.40.0+). Default: {}",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "kubeStateMetricsCore": {
+              "description": "KubeStateMetricsCore check configuration.",
               "properties": {
                 "conf": {
+                  "description": "Conf overrides the configuration for the default Kubernetes State Metrics Core check. This must point to a ConfigMap containing a valid cluster check configuration.",
                   "properties": {
                     "configData": {
+                      "description": "ConfigData corresponds to the configuration file content.",
                       "type": "string"
                     },
                     "configMap": {
+                      "description": "ConfigMap references an existing ConfigMap with the configuration file content.",
                       "properties": {
                         "items": {
+                          "description": "Items maps a ConfigMap data `key` to a file `path` mount.",
                           "items": {
+                            "description": "Maps a string key to a path within a volume.",
                             "properties": {
                               "key": {
+                                "description": "key is the key to project.",
                                 "type": "string"
                               },
                               "mode": {
+                                "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                 "format": "int32",
                                 "type": "integer"
                               },
                               "path": {
+                                "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                 "type": "string"
                               }
                             },
@@ -389,6 +599,7 @@
                           "x-kubernetes-list-type": "map"
                         },
                         "name": {
+                          "description": "Name is the name of the ConfigMap.",
                           "type": "string"
                         }
                       },
@@ -400,6 +611,7 @@
                   "additionalProperties": false
                 },
                 "enabled": {
+                  "description": "Enabled enables Kube State Metrics Core. Default: true",
                   "type": "boolean"
                 }
               },
@@ -407,8 +619,10 @@
               "additionalProperties": false
             },
             "liveContainerCollection": {
+              "description": "LiveContainerCollection configuration.",
               "properties": {
                 "enabled": {
+                  "description": "Enables container collection for the Live Container View. Default: true",
                   "type": "boolean"
                 }
               },
@@ -416,14 +630,18 @@
               "additionalProperties": false
             },
             "liveProcessCollection": {
+              "description": "LiveProcessCollection configuration.",
               "properties": {
                 "enabled": {
+                  "description": "Enabled enables Process monitoring. Default: false",
                   "type": "boolean"
                 },
                 "scrubProcessArguments": {
+                  "description": "ScrubProcessArguments enables scrubbing of sensitive data in process command-lines (passwords, tokens, etc. ). Default: true",
                   "type": "boolean"
                 },
                 "stripProcessArguments": {
+                  "description": "StripProcessArguments enables stripping of all process arguments. Default: false",
                   "type": "boolean"
                 }
               },
@@ -431,30 +649,39 @@
               "additionalProperties": false
             },
             "logCollection": {
+              "description": "LogCollection configuration.",
               "properties": {
                 "containerCollectAll": {
+                  "description": "ContainerCollectAll enables Log collection from all containers. Default: false",
                   "type": "boolean"
                 },
                 "containerCollectUsingFiles": {
+                  "description": "ContainerCollectUsingFiles enables log collection from files in `/var/log/pods instead` of using the container runtime API. Collecting logs from files is usually the most efficient way of collecting logs. See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup Default: true",
                   "type": "boolean"
                 },
                 "containerLogsPath": {
+                  "description": "ContainerLogsPath allows log collection from the container log path. Set to a different path if you are not using the Docker runtime. See also: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#create-manifest Default: `/var/lib/docker/containers`",
                   "type": "string"
                 },
                 "containerSymlinksPath": {
+                  "description": "ContainerSymlinksPath allows log collection to use symbolic links in this directory to validate container ID -> pod. Default: `/var/log/containers`",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "Enabled enables Log collection. Default: false",
                   "type": "boolean"
                 },
                 "openFilesLimit": {
+                  "description": "OpenFilesLimit sets the maximum number of log files that the Datadog Agent tails. Increasing this limit can increase resource consumption of the Agent. See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup Default: 100",
                   "format": "int32",
                   "type": "integer"
                 },
                 "podLogsPath": {
+                  "description": "PodLogsPath allows log collection from a pod log path. Default: `/var/log/pods`",
                   "type": "string"
                 },
                 "tempStoragePath": {
+                  "description": "TempStoragePath (always mounted from the host) is used by the Agent to store information about processed log files. If the Agent is restarted, it starts tailing the log files immediately. Default: `/var/lib/datadog-agent/logs`",
                   "type": "string"
                 }
               },
@@ -462,14 +689,18 @@
               "additionalProperties": false
             },
             "npm": {
+              "description": "NPM (Network Performance Monitoring) configuration.",
               "properties": {
                 "collectDNSStats": {
+                  "description": "CollectDNSStats enables DNS stat collection. Default: false",
                   "type": "boolean"
                 },
                 "enableConntrack": {
+                  "description": "EnableConntrack enables the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data. See also: http://conntrack-tools.netfilter.org/ Default: false",
                   "type": "boolean"
                 },
                 "enabled": {
+                  "description": "Enabled enables Network Performance Monitoring. Default: false",
                   "type": "boolean"
                 }
               },
@@ -477,8 +708,10 @@
               "additionalProperties": false
             },
             "oomKill": {
+              "description": "OOMKill configuration.",
               "properties": {
                 "enabled": {
+                  "description": "Enables the OOMKill eBPF-based check. Default: false",
                   "type": "boolean"
                 }
               },
@@ -486,25 +719,34 @@
               "additionalProperties": false
             },
             "orchestratorExplorer": {
+              "description": "OrchestratorExplorer check configuration.",
               "properties": {
                 "conf": {
+                  "description": "Conf overrides the configuration for the default Orchestrator Explorer check. This must point to a ConfigMap containing a valid cluster check configuration.",
                   "properties": {
                     "configData": {
+                      "description": "ConfigData corresponds to the configuration file content.",
                       "type": "string"
                     },
                     "configMap": {
+                      "description": "ConfigMap references an existing ConfigMap with the configuration file content.",
                       "properties": {
                         "items": {
+                          "description": "Items maps a ConfigMap data `key` to a file `path` mount.",
                           "items": {
+                            "description": "Maps a string key to a path within a volume.",
                             "properties": {
                               "key": {
+                                "description": "key is the key to project.",
                                 "type": "string"
                               },
                               "mode": {
+                                "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                 "format": "int32",
                                 "type": "integer"
                               },
                               "path": {
+                                "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                 "type": "string"
                               }
                             },
@@ -522,6 +764,7 @@
                           "x-kubernetes-list-type": "map"
                         },
                         "name": {
+                          "description": "Name is the name of the ConfigMap.",
                           "type": "string"
                         }
                       },
@@ -532,13 +775,24 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "customResources": {
+                  "description": "`CustomResources` defines custom resources for the orchestrator explorer to collect. Each item should follow the convention `group/version/kind`. For example, `datadoghq.com/v1alpha1/datadogmetrics`.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
                 "ddUrl": {
+                  "description": "Override the API endpoint for the Orchestrator Explorer. URL Default: \"https://orchestrator.datadoghq.com\".",
                   "type": "string"
                 },
                 "enabled": {
+                  "description": "Enabled enables the Orchestrator Explorer. Default: true",
                   "type": "boolean"
                 },
                 "extraTags": {
+                  "description": "Additional tags to associate with the collected data in the form of `a b c`. This is a Cluster Agent option distinct from DD_TAGS that is used in the Orchestrator Explorer.",
                   "items": {
                     "type": "string"
                   },
@@ -546,6 +800,7 @@
                   "x-kubernetes-list-type": "set"
                 },
                 "scrubContainers": {
+                  "description": "ScrubContainers enables scrubbing of sensitive container data (passwords, tokens, etc. ). Default: true",
                   "type": "boolean"
                 }
               },
@@ -553,17 +808,23 @@
               "additionalProperties": false
             },
             "otlp": {
+              "description": "OTLP ingest configuration",
               "properties": {
                 "receiver": {
+                  "description": "Receiver contains configuration for the OTLP ingest receiver.",
                   "properties": {
                     "protocols": {
+                      "description": "Protocols contains configuration for the OTLP ingest receiver protocols.",
                       "properties": {
                         "grpc": {
+                          "description": "GRPC contains configuration for the OTLP ingest OTLP/gRPC receiver.",
                           "properties": {
                             "enabled": {
+                              "description": "Enable the OTLP/gRPC endpoint.",
                               "type": "boolean"
                             },
                             "endpoint": {
+                              "description": "Endpoint for OTLP/gRPC. gRPC supports several naming schemes: https://github.com/grpc/grpc/blob/master/doc/naming.md The Datadog Operator supports only 'host:port' (usually `0.0.0.0:port`). Default: `0.0.0.0:4317`.",
                               "type": "string"
                             }
                           },
@@ -571,11 +832,14 @@
                           "additionalProperties": false
                         },
                         "http": {
+                          "description": "HTTP contains configuration for the OTLP ingest OTLP/HTTP receiver.",
                           "properties": {
                             "enabled": {
+                              "description": "Enable the OTLP/HTTP endpoint.",
                               "type": "boolean"
                             },
                             "endpoint": {
+                              "description": "Endpoint for OTLP/HTTP. Default: '0.0.0.0:4318'.",
                               "type": "string"
                             }
                           },
@@ -594,27 +858,105 @@
               "type": "object",
               "additionalProperties": false
             },
+            "processDiscovery": {
+              "description": "ProcessDiscovery configuration.",
+              "properties": {
+                "enabled": {
+                  "description": "Enabled enables the Process Discovery check in the Agent. Default: true",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "prometheusScrape": {
+              "description": "PrometheusScrape configuration.",
               "properties": {
                 "additionalConfigs": {
+                  "description": "AdditionalConfigs allows adding advanced Prometheus check configurations with custom discovery rules.",
                   "type": "string"
                 },
                 "enableServiceEndpoints": {
+                  "description": "EnableServiceEndpoints enables generating dedicated checks for service endpoints. Default: false",
                   "type": "boolean"
                 },
                 "enabled": {
+                  "description": "Enable autodiscovery of pods and services exposing Prometheus metrics. Default: false",
                   "type": "boolean"
                 },
                 "version": {
+                  "description": "Version specifies the version of the OpenMetrics check. Default: 2",
                   "type": "integer"
                 }
               },
               "type": "object",
               "additionalProperties": false
             },
-            "tcpQueueLength": {
+            "remoteConfiguration": {
+              "description": "Remote Configuration configuration.",
               "properties": {
                 "enabled": {
+                  "description": "Enable this option to activate Remote Configuration. Default: true",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sbom": {
+              "description": "SBOM collection configuration.",
+              "properties": {
+                "containerImage": {
+                  "description": "SBOMTypeConfig contains configuration for a SBOM collection type.",
+                  "properties": {
+                    "analyzers": {
+                      "description": "Analyzers to use for SBOM collection.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "enabled": {
+                      "description": "Enable this option to activate SBOM collection. Default: false",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "enabled": {
+                  "description": "Enable this option to activate SBOM collection. Default: false",
+                  "type": "boolean"
+                },
+                "host": {
+                  "description": "SBOMTypeConfig contains configuration for a SBOM collection type.",
+                  "properties": {
+                    "analyzers": {
+                      "description": "Analyzers to use for SBOM collection.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "enabled": {
+                      "description": "Enable this option to activate SBOM collection. Default: false",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tcpQueueLength": {
+              "description": "TCPQueueLength configuration.",
+              "properties": {
+                "enabled": {
+                  "description": "Enables the TCP queue length eBPF-based check. Default: false",
                   "type": "boolean"
                 }
               },
@@ -622,8 +964,10 @@
               "additionalProperties": false
             },
             "usm": {
+              "description": "USM (Universal Service Monitoring) configuration.",
               "properties": {
                 "enabled": {
+                  "description": "Enabled enables Universal Service Monitoring. Default: false",
                   "type": "boolean"
                 }
               },
@@ -635,16 +979,21 @@
           "additionalProperties": false
         },
         "global": {
+          "description": "Global settings to configure the agents",
           "properties": {
             "clusterAgentToken": {
+              "description": "ClusterAgentToken is the token for communication between the NodeAgent and ClusterAgent.",
               "type": "string"
             },
             "clusterAgentTokenSecret": {
+              "description": "ClusterAgentTokenSecret is the secret containing the Cluster Agent token.",
               "properties": {
                 "keyName": {
+                  "description": "KeyName is the key of the secret to use.",
                   "type": "string"
                 },
                 "secretName": {
+                  "description": "SecretName is the name of the secret.",
                   "type": "string"
                 }
               },
@@ -655,19 +1004,29 @@
               "additionalProperties": false
             },
             "clusterName": {
+              "description": "ClusterName sets a unique cluster name for the deployment to easily scope monitoring data in the Datadog app.",
+              "type": "string"
+            },
+            "containerStrategy": {
+              "description": "ContainerStrategy determines whether agents run in a single or multiple containers. Default: 'optimized'",
               "type": "string"
             },
             "credentials": {
+              "description": "Credentials defines the Datadog credentials used to submit data to/query data from Datadog.",
               "properties": {
                 "apiKey": {
+                  "description": "APIKey configures your Datadog API key. See also: https://app.datadoghq.com/account/settings#agent/kubernetes",
                   "type": "string"
                 },
                 "apiSecret": {
+                  "description": "APISecret references an existing Secret which stores the API key instead of creating a new one. If set, this parameter takes precedence over \"APIKey\".",
                   "properties": {
                     "keyName": {
+                      "description": "KeyName is the key of the secret to use.",
                       "type": "string"
                     },
                     "secretName": {
+                      "description": "SecretName is the name of the secret.",
                       "type": "string"
                     }
                   },
@@ -678,14 +1037,18 @@
                   "additionalProperties": false
                 },
                 "appKey": {
+                  "description": "AppKey configures your Datadog application key. If you are using features.externalMetricsServer.enabled = true, you must set a Datadog application key for read access to your metrics.",
                   "type": "string"
                 },
                 "appSecret": {
+                  "description": "AppSecret references an existing Secret which stores the application key instead of creating a new one. If set, this parameter takes precedence over \"AppKey\".",
                   "properties": {
                     "keyName": {
+                      "description": "KeyName is the key of the secret to use.",
                       "type": "string"
                     },
                     "secretName": {
+                      "description": "SecretName is the name of the secret.",
                       "type": "string"
                     }
                   },
@@ -700,24 +1063,36 @@
               "additionalProperties": false
             },
             "criSocketPath": {
+              "description": "Path to the container runtime socket (if different from Docker).",
               "type": "string"
             },
+            "disableNonResourceRules": {
+              "description": "Set DisableNonResourceRules to exclude NonResourceURLs from default ClusterRoles. Required 'true' for Google Cloud Marketplace.",
+              "type": "boolean"
+            },
             "dockerSocketPath": {
+              "description": "Path to the docker runtime socket.",
               "type": "string"
             },
             "endpoint": {
+              "description": "Endpoint is the Datadog intake URL the Agent data are sent to. Only set this option if you need the Agent to send data to a custom URL. Overrides the site setting defined in `Site`.",
               "properties": {
                 "credentials": {
+                  "description": "Credentials defines the Datadog credentials used to submit data to/query data from Datadog.",
                   "properties": {
                     "apiKey": {
+                      "description": "APIKey configures your Datadog API key. See also: https://app.datadoghq.com/account/settings#agent/kubernetes",
                       "type": "string"
                     },
                     "apiSecret": {
+                      "description": "APISecret references an existing Secret which stores the API key instead of creating a new one. If set, this parameter takes precedence over \"APIKey\".",
                       "properties": {
                         "keyName": {
+                          "description": "KeyName is the key of the secret to use.",
                           "type": "string"
                         },
                         "secretName": {
+                          "description": "SecretName is the name of the secret.",
                           "type": "string"
                         }
                       },
@@ -728,14 +1103,18 @@
                       "additionalProperties": false
                     },
                     "appKey": {
+                      "description": "AppKey configures your Datadog application key. If you are using features.externalMetricsServer.enabled = true, you must set a Datadog application key for read access to your metrics.",
                       "type": "string"
                     },
                     "appSecret": {
+                      "description": "AppSecret references an existing Secret which stores the application key instead of creating a new one. If set, this parameter takes precedence over \"AppKey\".",
                       "properties": {
                         "keyName": {
+                          "description": "KeyName is the key of the secret to use.",
                           "type": "string"
                         },
                         "secretName": {
+                          "description": "SecretName is the name of the secret.",
                           "type": "string"
                         }
                       },
@@ -750,28 +1129,196 @@
                   "additionalProperties": false
                 },
                 "url": {
+                  "description": "URL defines the endpoint URL.",
                   "type": "string"
                 }
               },
               "type": "object",
               "additionalProperties": false
             },
+            "fips": {
+              "description": "FIPS contains configuration used to customize the FIPS proxy sidecar.",
+              "properties": {
+                "customFIPSConfig": {
+                  "description": "CustomFIPSConfig configures a custom configMap to provide the FIPS configuration. Specify custom contents for the FIPS proxy sidecar container config (/etc/datadog-fips-proxy/datadog-fips-proxy.cfg). If empty, the default FIPS proxy sidecar container config is used.",
+                  "properties": {
+                    "configData": {
+                      "description": "ConfigData corresponds to the configuration file content.",
+                      "type": "string"
+                    },
+                    "configMap": {
+                      "description": "ConfigMap references an existing ConfigMap with the configuration file content.",
+                      "properties": {
+                        "items": {
+                          "description": "Items maps a ConfigMap data `key` to a file `path` mount.",
+                          "items": {
+                            "description": "Maps a string key to a path within a volume.",
+                            "properties": {
+                              "key": {
+                                "description": "key is the key to project.",
+                                "type": "string"
+                              },
+                              "mode": {
+                                "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "path": {
+                                "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "path"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "key"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "name": {
+                          "description": "Name is the name of the ConfigMap.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "enabled": {
+                  "description": "Enable FIPS sidecar.",
+                  "type": "boolean"
+                },
+                "image": {
+                  "description": "The container image of the FIPS sidecar.",
+                  "properties": {
+                    "jmxEnabled": {
+                      "description": "Define whether the Agent image should support JMX. To be used if the Name field does not correspond to a full image string.",
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "description": "Define the image to use: Use \"gcr.io/datadoghq/agent:latest\" for Datadog Agent 7. Use \"datadog/dogstatsd:latest\" for standalone Datadog Agent DogStatsD 7. Use \"gcr.io/datadoghq/cluster-agent:latest\" for Datadog Cluster Agent. Use \"agent\" with the registry and tag configurations for <registry>/agent:<tag>. Use \"cluster-agent\" with the registry and tag configurations for <registry>/cluster-agent:<tag>. If the name is the full image string\u2014`<name>:<tag>` or `<registry>/<name>:<tag>`, then `tag`, `jmxEnabled`, and `global.registry` values are ignored. Otherwise, image string is created by overriding default settings with supplied `name`, `tag`, and `jmxEnabled` values; image string is created using default registry unless `global.registry` is configured.",
+                      "type": "string"
+                    },
+                    "pullPolicy": {
+                      "description": "The Kubernetes pull policy: Use Always, Never, or IfNotPresent.",
+                      "type": "string"
+                    },
+                    "pullSecrets": {
+                      "description": "It is possible to specify Docker registry credentials. See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
+                      "items": {
+                        "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "tag": {
+                      "description": "Define the image tag to use. To be used if the Name field does not correspond to a full image string.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "localAddress": {
+                  "description": "Set the local IP address. Default: `127.0.0.1`",
+                  "type": "string"
+                },
+                "port": {
+                  "description": "Port specifies which port is used by the containers to communicate to the FIPS sidecar. Default: 9803",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "portRange": {
+                  "description": "PortRange specifies the number of ports used. Default: 15",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "resources": {
+                  "description": "Resources is the requests and limits for the FIPS sidecar container.",
+                  "properties": {
+                    "limits": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "useHTTPS": {
+                  "description": "UseHTTPS enables HTTPS. Default: false",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "kubelet": {
+              "description": "Kubelet contains the kubelet configuration parameters.",
               "properties": {
                 "agentCAPath": {
+                  "description": "AgentCAPath is the container path where the kubelet CA certificate is stored. Default: '/var/run/host-kubelet-ca.crt' if hostCAPath is set, else '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'",
                   "type": "string"
                 },
                 "host": {
+                  "description": "Host overrides the host used to contact kubelet API (default to status.hostIP).",
                   "properties": {
                     "configMapKeyRef": {
+                      "description": "Selects a key of a ConfigMap.",
                       "properties": {
                         "key": {
+                          "description": "The key to select.",
                           "type": "string"
                         },
                         "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                           "type": "string"
                         },
                         "optional": {
+                          "description": "Specify whether the ConfigMap or its key must be defined",
                           "type": "boolean"
                         }
                       },
@@ -782,11 +1329,14 @@
                       "additionalProperties": false
                     },
                     "fieldRef": {
+                      "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                       "properties": {
                         "apiVersion": {
+                          "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                           "type": "string"
                         },
                         "fieldPath": {
+                          "description": "Path of the field to select in the specified API version.",
                           "type": "string"
                         }
                       },
@@ -797,8 +1347,10 @@
                       "additionalProperties": false
                     },
                     "resourceFieldRef": {
+                      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                       "properties": {
                         "containerName": {
+                          "description": "Container name: required for volumes, optional for env vars",
                           "type": "string"
                         },
                         "divisor": {
@@ -810,10 +1362,12 @@
                               "type": "string"
                             }
                           ],
+                          "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                           "x-kubernetes-int-or-string": true
                         },
                         "resource": {
+                          "description": "Required: resource to select",
                           "type": "string"
                         }
                       },
@@ -824,14 +1378,18 @@
                       "additionalProperties": false
                     },
                     "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
                       "properties": {
                         "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
                           "type": "string"
                         },
                         "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                           "type": "string"
                         },
                         "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
                           "type": "boolean"
                         }
                       },
@@ -846,9 +1404,11 @@
                   "additionalProperties": false
                 },
                 "hostCAPath": {
+                  "description": "HostCAPath is the host path where the kubelet CA certificate is stored.",
                   "type": "string"
                 },
                 "tlsVerify": {
+                  "description": "TLSVerify toggles kubelet TLS verification. Default: true",
                   "type": "boolean"
                 }
               },
@@ -856,11 +1416,14 @@
               "additionalProperties": false
             },
             "localService": {
+              "description": "LocalService contains configuration to customize the internal traffic policy service.",
               "properties": {
                 "forceEnableLocalService": {
+                  "description": "ForceEnableLocalService forces the creation of the internal traffic policy service to target the agent running on the local node. This parameter only applies to Kubernetes 1.21, where the feature is in alpha and is disabled by default. (On Kubernetes 1.22+, the feature entered beta and the internal traffic service is created by default, so this parameter is ignored.) Default: false",
                   "type": "boolean"
                 },
                 "nameOverride": {
+                  "description": "NameOverride defines the name of the internal traffic service to target the agent running on the local node.",
                   "type": "string"
                 }
               },
@@ -868,26 +1431,43 @@
               "additionalProperties": false
             },
             "logLevel": {
+              "description": "LogLevel sets logging verbosity. This can be overridden by container. Valid log levels are: trace, debug, info, warn, error, critical, and off. Default: 'info'",
               "type": "string"
             },
+            "namespaceLabelsAsTags": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Provide a mapping of Kubernetes Namespace Labels to Datadog Tags. <KUBERNETES_NAMESPACE_LABEL>: <DATADOG_TAG_KEY>",
+              "type": "object"
+            },
             "networkPolicy": {
+              "description": "NetworkPolicy contains the network configuration.",
               "properties": {
                 "create": {
+                  "description": "Create defines whether to create a NetworkPolicy for the current deployment.",
                   "type": "boolean"
                 },
                 "dnsSelectorEndpoints": {
+                  "description": "DNSSelectorEndpoints defines the cilium selector of the DNS\u202fserver entity.",
                   "items": {
+                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
                     "properties": {
                       "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                         "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                           "properties": {
                             "key": {
+                              "description": "key is the label key that the selector applies to.",
                               "type": "string"
                             },
                             "operator": {
+                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                               "type": "string"
                             },
                             "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                               "items": {
                                 "type": "string"
                               },
@@ -907,6 +1487,7 @@
                         "additionalProperties": {
                           "type": "string"
                         },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                         "type": "object"
                       }
                     },
@@ -917,43 +1498,44 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "flavor": {
+                  "description": "Flavor defines Which network policy to use.",
                   "type": "string"
                 }
               },
               "type": "object",
               "additionalProperties": false
             },
-            "namespaceLabelsAsTags": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object"
-            },
             "nodeLabelsAsTags": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "Provide a mapping of Kubernetes Node Labels to Datadog Tags. <KUBERNETES_NODE_LABEL>: <DATADOG_TAG_KEY>",
               "type": "object"
             },
             "podAnnotationsAsTags": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "Provide a mapping of Kubernetes Annotations to Datadog Tags. <KUBERNETES_ANNOTATIONS>: <DATADOG_TAG_KEY>",
               "type": "object"
             },
             "podLabelsAsTags": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "Provide a mapping of Kubernetes Labels to Datadog Tags. <KUBERNETES_LABEL>: <DATADOG_TAG_KEY>",
               "type": "object"
             },
             "registry": {
+              "description": "Registry is the image registry to use for all Agent images. Use 'public.ecr.aws/datadog' for AWS ECR. Use 'docker.io/datadog' for DockerHub. Default: 'gcr.io/datadoghq'",
               "type": "string"
             },
             "site": {
+              "description": "Site is the Datadog intake site Agent data are sent to. Set to 'datadoghq.com' to send data to the US1 site (default). Set to 'datadoghq.eu' to send data to the EU site. Set to 'us3.datadoghq.com' to send data to the US3 site. Set to 'us5.datadoghq.com' to send data to the US5 site. Set to 'ddog-gov.com' to send data to the US1-FED site. Set to 'ap1.datadoghq.com' to send data to the AP1 site. Default: 'datadoghq.com'",
               "type": "string"
             },
             "tags": {
+              "description": "Tags contains a list of tags to attach to every metric, event and service check collected. Learn more about tagging: https://docs.datadoghq.com/tagging/",
               "items": {
                 "type": "string"
               },
@@ -966,26 +1548,37 @@
         },
         "override": {
           "additionalProperties": {
+            "description": "DatadogAgentComponentOverride is the generic description equivalent to a subset of the PodTemplate for a component.",
             "properties": {
               "affinity": {
+                "description": "If specified, the pod's scheduling constraints.",
                 "properties": {
                   "nodeAffinity": {
+                    "description": "Describes node affinity scheduling rules for the pod.",
                     "properties": {
                       "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
                         "items": {
+                          "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
                           "properties": {
                             "preference": {
+                              "description": "A node selector term, associated with the corresponding weight.",
                               "properties": {
                                 "matchExpressions": {
+                                  "description": "A list of node selector requirements by node's labels.",
                                   "items": {
+                                    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                     "properties": {
                                       "key": {
+                                        "description": "The label key that the selector applies to.",
                                         "type": "string"
                                       },
                                       "operator": {
+                                        "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                         "type": "string"
                                       },
                                       "values": {
+                                        "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -1002,15 +1595,20 @@
                                   "type": "array"
                                 },
                                 "matchFields": {
+                                  "description": "A list of node selector requirements by node's fields.",
                                   "items": {
+                                    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                     "properties": {
                                       "key": {
+                                        "description": "The label key that the selector applies to.",
                                         "type": "string"
                                       },
                                       "operator": {
+                                        "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                         "type": "string"
                                       },
                                       "values": {
+                                        "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -1031,6 +1629,7 @@
                               "additionalProperties": false
                             },
                             "weight": {
+                              "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
                               "format": "int32",
                               "type": "integer"
                             }
@@ -1045,20 +1644,28 @@
                         "type": "array"
                       },
                       "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
                         "properties": {
                           "nodeSelectorTerms": {
+                            "description": "Required. A list of node selector terms. The terms are ORed.",
                             "items": {
+                              "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
                               "properties": {
                                 "matchExpressions": {
+                                  "description": "A list of node selector requirements by node's labels.",
                                   "items": {
+                                    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                     "properties": {
                                       "key": {
+                                        "description": "The label key that the selector applies to.",
                                         "type": "string"
                                       },
                                       "operator": {
+                                        "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                         "type": "string"
                                       },
                                       "values": {
+                                        "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -1075,15 +1682,20 @@
                                   "type": "array"
                                 },
                                 "matchFields": {
+                                  "description": "A list of node selector requirements by node's fields.",
                                   "items": {
+                                    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                     "properties": {
                                       "key": {
+                                        "description": "The label key that the selector applies to.",
                                         "type": "string"
                                       },
                                       "operator": {
+                                        "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                         "type": "string"
                                       },
                                       "values": {
+                                        "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -1117,24 +1729,34 @@
                     "additionalProperties": false
                   },
                   "podAffinity": {
+                    "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
                     "properties": {
                       "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
                         "items": {
+                          "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
                           "properties": {
                             "podAffinityTerm": {
+                              "description": "Required. A pod affinity term, associated with the corresponding weight.",
                               "properties": {
                                 "labelSelector": {
+                                  "description": "A label query over a set of resources, in this case pods.",
                                   "properties": {
                                     "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                       "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                         "properties": {
                                           "key": {
+                                            "description": "key is the label key that the selector applies to.",
                                             "type": "string"
                                           },
                                           "operator": {
+                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                             "type": "string"
                                           },
                                           "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -1154,6 +1776,7 @@
                                       "additionalProperties": {
                                         "type": "string"
                                       },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                       "type": "object"
                                     }
                                   },
@@ -1161,17 +1784,23 @@
                                   "additionalProperties": false
                                 },
                                 "namespaceSelector": {
+                                  "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                                   "properties": {
                                     "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                       "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                         "properties": {
                                           "key": {
+                                            "description": "key is the label key that the selector applies to.",
                                             "type": "string"
                                           },
                                           "operator": {
+                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                             "type": "string"
                                           },
                                           "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -1191,6 +1820,7 @@
                                       "additionalProperties": {
                                         "type": "string"
                                       },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                       "type": "object"
                                     }
                                   },
@@ -1198,12 +1828,14 @@
                                   "additionalProperties": false
                                 },
                                 "namespaces": {
+                                  "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                                   "items": {
                                     "type": "string"
                                   },
                                   "type": "array"
                                 },
                                 "topologyKey": {
+                                  "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                   "type": "string"
                                 }
                               },
@@ -1214,6 +1846,7 @@
                               "additionalProperties": false
                             },
                             "weight": {
+                              "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
                               "format": "int32",
                               "type": "integer"
                             }
@@ -1228,20 +1861,28 @@
                         "type": "array"
                       },
                       "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
                         "items": {
+                          "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
                           "properties": {
                             "labelSelector": {
+                              "description": "A label query over a set of resources, in this case pods.",
                               "properties": {
                                 "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                   "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                     "properties": {
                                       "key": {
+                                        "description": "key is the label key that the selector applies to.",
                                         "type": "string"
                                       },
                                       "operator": {
+                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                         "type": "string"
                                       },
                                       "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -1261,6 +1902,7 @@
                                   "additionalProperties": {
                                     "type": "string"
                                   },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                   "type": "object"
                                 }
                               },
@@ -1268,17 +1910,23 @@
                               "additionalProperties": false
                             },
                             "namespaceSelector": {
+                              "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                               "properties": {
                                 "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                   "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                     "properties": {
                                       "key": {
+                                        "description": "key is the label key that the selector applies to.",
                                         "type": "string"
                                       },
                                       "operator": {
+                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                         "type": "string"
                                       },
                                       "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -1298,6 +1946,7 @@
                                   "additionalProperties": {
                                     "type": "string"
                                   },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                   "type": "object"
                                 }
                               },
@@ -1305,12 +1954,14 @@
                               "additionalProperties": false
                             },
                             "namespaces": {
+                              "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                               "items": {
                                 "type": "string"
                               },
                               "type": "array"
                             },
                             "topologyKey": {
+                              "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                               "type": "string"
                             }
                           },
@@ -1327,24 +1978,34 @@
                     "additionalProperties": false
                   },
                   "podAntiAffinity": {
+                    "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
                     "properties": {
                       "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
                         "items": {
+                          "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
                           "properties": {
                             "podAffinityTerm": {
+                              "description": "Required. A pod affinity term, associated with the corresponding weight.",
                               "properties": {
                                 "labelSelector": {
+                                  "description": "A label query over a set of resources, in this case pods.",
                                   "properties": {
                                     "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                       "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                         "properties": {
                                           "key": {
+                                            "description": "key is the label key that the selector applies to.",
                                             "type": "string"
                                           },
                                           "operator": {
+                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                             "type": "string"
                                           },
                                           "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -1364,6 +2025,7 @@
                                       "additionalProperties": {
                                         "type": "string"
                                       },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                       "type": "object"
                                     }
                                   },
@@ -1371,17 +2033,23 @@
                                   "additionalProperties": false
                                 },
                                 "namespaceSelector": {
+                                  "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                                   "properties": {
                                     "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                       "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                         "properties": {
                                           "key": {
+                                            "description": "key is the label key that the selector applies to.",
                                             "type": "string"
                                           },
                                           "operator": {
+                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                             "type": "string"
                                           },
                                           "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -1401,6 +2069,7 @@
                                       "additionalProperties": {
                                         "type": "string"
                                       },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                       "type": "object"
                                     }
                                   },
@@ -1408,12 +2077,14 @@
                                   "additionalProperties": false
                                 },
                                 "namespaces": {
+                                  "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                                   "items": {
                                     "type": "string"
                                   },
                                   "type": "array"
                                 },
                                 "topologyKey": {
+                                  "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                   "type": "string"
                                 }
                               },
@@ -1424,6 +2095,7 @@
                               "additionalProperties": false
                             },
                             "weight": {
+                              "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
                               "format": "int32",
                               "type": "integer"
                             }
@@ -1438,20 +2110,28 @@
                         "type": "array"
                       },
                       "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
                         "items": {
+                          "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
                           "properties": {
                             "labelSelector": {
+                              "description": "A label query over a set of resources, in this case pods.",
                               "properties": {
                                 "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                   "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                     "properties": {
                                       "key": {
+                                        "description": "key is the label key that the selector applies to.",
                                         "type": "string"
                                       },
                                       "operator": {
+                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                         "type": "string"
                                       },
                                       "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -1471,6 +2151,7 @@
                                   "additionalProperties": {
                                     "type": "string"
                                   },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                   "type": "object"
                                 }
                               },
@@ -1478,17 +2159,23 @@
                               "additionalProperties": false
                             },
                             "namespaceSelector": {
+                              "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                               "properties": {
                                 "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                   "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                     "properties": {
                                       "key": {
+                                        "description": "key is the label key that the selector applies to.",
                                         "type": "string"
                                       },
                                       "operator": {
+                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                         "type": "string"
                                       },
                                       "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -1508,6 +2195,7 @@
                                   "additionalProperties": {
                                     "type": "string"
                                   },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                   "type": "object"
                                 }
                               },
@@ -1515,12 +2203,14 @@
                               "additionalProperties": false
                             },
                             "namespaces": {
+                              "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                               "items": {
                                 "type": "string"
                               },
                               "type": "array"
                             },
                             "topologyKey": {
+                              "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                               "type": "string"
                             }
                           },
@@ -1544,15 +2234,19 @@
                 "additionalProperties": {
                   "type": "string"
                 },
+                "description": "Annotations provide annotations that are added to the different component (Datadog Agent, Cluster Agent, Cluster Check Runner) pods.",
                 "type": "object"
               },
               "containers": {
                 "additionalProperties": {
+                  "description": "DatadogAgentGenericContainer is the generic structure describing any container's common configuration.",
                   "properties": {
                     "appArmorProfileName": {
+                      "description": "AppArmorProfileName specifies an apparmor profile.",
                       "type": "string"
                     },
                     "args": {
+                      "description": "Args allows the specification of extra args to the `Command` parameter",
                       "items": {
                         "type": "string"
                       },
@@ -1560,6 +2254,7 @@
                       "x-kubernetes-list-type": "atomic"
                     },
                     "command": {
+                      "description": "Command allows the specification of a custom entrypoint for container",
                       "items": {
                         "type": "string"
                       },
@@ -1567,25 +2262,34 @@
                       "x-kubernetes-list-type": "atomic"
                     },
                     "env": {
+                      "description": "Specify additional environment variables in the container. See also: https://docs.datadoghq.com/agent/kubernetes/?tab=helm#environment-variables",
                       "items": {
+                        "description": "EnvVar represents an environment variable present in a Container.",
                         "properties": {
                           "name": {
+                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                             "type": "string"
                           },
                           "value": {
+                            "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
                             "type": "string"
                           },
                           "valueFrom": {
+                            "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                             "properties": {
                               "configMapKeyRef": {
+                                "description": "Selects a key of a ConfigMap.",
                                 "properties": {
                                   "key": {
+                                    "description": "The key to select.",
                                     "type": "string"
                                   },
                                   "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                     "type": "string"
                                   },
                                   "optional": {
+                                    "description": "Specify whether the ConfigMap or its key must be defined",
                                     "type": "boolean"
                                   }
                                 },
@@ -1596,11 +2300,14 @@
                                 "additionalProperties": false
                               },
                               "fieldRef": {
+                                "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                                 "properties": {
                                   "apiVersion": {
+                                    "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                     "type": "string"
                                   },
                                   "fieldPath": {
+                                    "description": "Path of the field to select in the specified API version.",
                                     "type": "string"
                                   }
                                 },
@@ -1611,8 +2318,10 @@
                                 "additionalProperties": false
                               },
                               "resourceFieldRef": {
+                                "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                                 "properties": {
                                   "containerName": {
+                                    "description": "Container name: required for volumes, optional for env vars",
                                     "type": "string"
                                   },
                                   "divisor": {
@@ -1624,10 +2333,12 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                     "x-kubernetes-int-or-string": true
                                   },
                                   "resource": {
+                                    "description": "Required: resource to select",
                                     "type": "string"
                                   }
                                 },
@@ -1638,14 +2349,18 @@
                                 "additionalProperties": false
                               },
                               "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
                                 "properties": {
                                   "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
                                     "type": "string"
                                   },
                                   "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                     "type": "string"
                                   },
                                   "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
                                     "type": "boolean"
                                   }
                                 },
@@ -1673,14 +2388,18 @@
                       "x-kubernetes-list-type": "map"
                     },
                     "healthPort": {
+                      "description": "HealthPort of the container for the internal liveness probe. Must be the same as the Liveness/Readiness probes.",
                       "format": "int32",
                       "type": "integer"
                     },
                     "livenessProbe": {
+                      "description": "Configure the Liveness Probe of the container",
                       "properties": {
                         "exec": {
+                          "description": "Exec specifies the action to take.",
                           "properties": {
                             "command": {
+                              "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                               "items": {
                                 "type": "string"
                               },
@@ -1691,16 +2410,20 @@
                           "additionalProperties": false
                         },
                         "failureThreshold": {
+                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "grpc": {
+                          "description": "GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.",
                           "properties": {
                             "port": {
+                              "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
                               "format": "int32",
                               "type": "integer"
                             },
                             "service": {
+                              "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
                               "type": "string"
                             }
                           },
@@ -1711,17 +2434,23 @@
                           "additionalProperties": false
                         },
                         "httpGet": {
+                          "description": "HTTPGet specifies the http request to perform.",
                           "properties": {
                             "host": {
+                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
                               "type": "string"
                             },
                             "httpHeaders": {
+                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                               "items": {
+                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                 "properties": {
                                   "name": {
+                                    "description": "The header field name",
                                     "type": "string"
                                   },
                                   "value": {
+                                    "description": "The header field value",
                                     "type": "string"
                                   }
                                 },
@@ -1735,6 +2464,7 @@
                               "type": "array"
                             },
                             "path": {
+                              "description": "Path to access on the HTTP server.",
                               "type": "string"
                             },
                             "port": {
@@ -1746,9 +2476,11 @@
                                   "type": "string"
                                 }
                               ],
+                              "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
                               "x-kubernetes-int-or-string": true
                             },
                             "scheme": {
+                              "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
                               "type": "string"
                             }
                           },
@@ -1759,20 +2491,25 @@
                           "additionalProperties": false
                         },
                         "initialDelaySeconds": {
+                          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                           "format": "int32",
                           "type": "integer"
                         },
                         "periodSeconds": {
+                          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "successThreshold": {
+                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "tcpSocket": {
+                          "description": "TCPSocket specifies an action involving a TCP port.",
                           "properties": {
                             "host": {
+                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
                               "type": "string"
                             },
                             "port": {
@@ -1784,6 +2521,7 @@
                                   "type": "string"
                                 }
                               ],
+                              "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
                               "x-kubernetes-int-or-string": true
                             }
                           },
@@ -1794,10 +2532,12 @@
                           "additionalProperties": false
                         },
                         "terminationGracePeriodSeconds": {
+                          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
                           "format": "int64",
                           "type": "integer"
                         },
                         "timeoutSeconds": {
+                          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                           "format": "int32",
                           "type": "integer"
                         }
@@ -1806,16 +2546,21 @@
                       "additionalProperties": false
                     },
                     "logLevel": {
+                      "description": "LogLevel sets logging verbosity (overrides global setting). Valid log levels are: trace, debug, info, warn, error, critical, and off. Default: 'info'",
                       "type": "string"
                     },
                     "name": {
+                      "description": "Name of the container that is overridden",
                       "type": "string"
                     },
                     "readinessProbe": {
+                      "description": "Configure the Readiness Probe of the container",
                       "properties": {
                         "exec": {
+                          "description": "Exec specifies the action to take.",
                           "properties": {
                             "command": {
+                              "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                               "items": {
                                 "type": "string"
                               },
@@ -1826,16 +2571,20 @@
                           "additionalProperties": false
                         },
                         "failureThreshold": {
+                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "grpc": {
+                          "description": "GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.",
                           "properties": {
                             "port": {
+                              "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
                               "format": "int32",
                               "type": "integer"
                             },
                             "service": {
+                              "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
                               "type": "string"
                             }
                           },
@@ -1846,17 +2595,23 @@
                           "additionalProperties": false
                         },
                         "httpGet": {
+                          "description": "HTTPGet specifies the http request to perform.",
                           "properties": {
                             "host": {
+                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
                               "type": "string"
                             },
                             "httpHeaders": {
+                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                               "items": {
+                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                 "properties": {
                                   "name": {
+                                    "description": "The header field name",
                                     "type": "string"
                                   },
                                   "value": {
+                                    "description": "The header field value",
                                     "type": "string"
                                   }
                                 },
@@ -1870,6 +2625,7 @@
                               "type": "array"
                             },
                             "path": {
+                              "description": "Path to access on the HTTP server.",
                               "type": "string"
                             },
                             "port": {
@@ -1881,9 +2637,11 @@
                                   "type": "string"
                                 }
                               ],
+                              "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
                               "x-kubernetes-int-or-string": true
                             },
                             "scheme": {
+                              "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
                               "type": "string"
                             }
                           },
@@ -1894,20 +2652,25 @@
                           "additionalProperties": false
                         },
                         "initialDelaySeconds": {
+                          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                           "format": "int32",
                           "type": "integer"
                         },
                         "periodSeconds": {
+                          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "successThreshold": {
+                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "tcpSocket": {
+                          "description": "TCPSocket specifies an action involving a TCP port.",
                           "properties": {
                             "host": {
+                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
                               "type": "string"
                             },
                             "port": {
@@ -1919,6 +2682,7 @@
                                   "type": "string"
                                 }
                               ],
+                              "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
                               "x-kubernetes-int-or-string": true
                             }
                           },
@@ -1929,10 +2693,12 @@
                           "additionalProperties": false
                         },
                         "terminationGracePeriodSeconds": {
+                          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
                           "format": "int64",
                           "type": "integer"
                         },
                         "timeoutSeconds": {
+                          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                           "format": "int32",
                           "type": "integer"
                         }
@@ -1941,6 +2707,7 @@
                       "additionalProperties": false
                     },
                     "resources": {
+                      "description": "Specify the Request and Limits of the pods To get guaranteed QoS class, specify requests and limits equal. See also: http://kubernetes.io/docs/user-guide/compute-resources/",
                       "properties": {
                         "limits": {
                           "additionalProperties": {
@@ -1955,6 +2722,7 @@
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
+                          "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                           "type": "object"
                         },
                         "requests": {
@@ -1970,6 +2738,7 @@
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
+                          "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                           "type": "object"
                         }
                       },
@@ -1977,25 +2746,34 @@
                       "additionalProperties": false
                     },
                     "seccompConfig": {
+                      "description": "Seccomp configurations to override Operator actions. For all other Seccomp Profile manipulation, use SecurityContext.",
                       "properties": {
                         "customProfile": {
+                          "description": "CustomProfile specifies a ConfigMap containing a custom Seccomp Profile. ConfigMap data must either have the key `system-probe-seccomp.json` or CustomProfile.Items must include a corev1.KeytoPath that maps the key to the path `system-probe-seccomp.json`.",
                           "properties": {
                             "configData": {
+                              "description": "ConfigData corresponds to the configuration file content.",
                               "type": "string"
                             },
                             "configMap": {
+                              "description": "ConfigMap references an existing ConfigMap with the configuration file content.",
                               "properties": {
                                 "items": {
+                                  "description": "Items maps a ConfigMap data `key` to a file `path` mount.",
                                   "items": {
+                                    "description": "Maps a string key to a path within a volume.",
                                     "properties": {
                                       "key": {
+                                        "description": "key is the key to project.",
                                         "type": "string"
                                       },
                                       "mode": {
+                                        "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                         "format": "int32",
                                         "type": "integer"
                                       },
                                       "path": {
+                                        "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                         "type": "string"
                                       }
                                     },
@@ -2013,6 +2791,7 @@
                                   "x-kubernetes-list-type": "map"
                                 },
                                 "name": {
+                                  "description": "Name is the name of the ConfigMap.",
                                   "type": "string"
                                 }
                               },
@@ -2024,6 +2803,7 @@
                           "additionalProperties": false
                         },
                         "customRootPath": {
+                          "description": "CustomRootPath specifies a custom Seccomp Profile root location.",
                           "type": "string"
                         }
                       },
@@ -2031,20 +2811,27 @@
                       "additionalProperties": false
                     },
                     "securityContext": {
+                      "description": "Container-level SecurityContext.",
                       "properties": {
                         "allowPrivilegeEscalation": {
+                          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
                           "type": "boolean"
                         },
                         "capabilities": {
+                          "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
                           "properties": {
                             "add": {
+                              "description": "Added capabilities",
                               "items": {
+                                "description": "Capability represent POSIX capabilities type",
                                 "type": "string"
                               },
                               "type": "array"
                             },
                             "drop": {
+                              "description": "Removed capabilities",
                               "items": {
+                                "description": "Capability represent POSIX capabilities type",
                                 "type": "string"
                               },
                               "type": "array"
@@ -2054,37 +2841,48 @@
                           "additionalProperties": false
                         },
                         "privileged": {
+                          "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
                           "type": "boolean"
                         },
                         "procMount": {
+                          "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
                           "type": "string"
                         },
                         "readOnlyRootFilesystem": {
+                          "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
                           "type": "boolean"
                         },
                         "runAsGroup": {
+                          "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
                           "format": "int64",
                           "type": "integer"
                         },
                         "runAsNonRoot": {
+                          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
                           "type": "boolean"
                         },
                         "runAsUser": {
+                          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
                           "format": "int64",
                           "type": "integer"
                         },
                         "seLinuxOptions": {
+                          "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
                           "properties": {
                             "level": {
+                              "description": "Level is SELinux level label that applies to the container.",
                               "type": "string"
                             },
                             "role": {
+                              "description": "Role is a SELinux role label that applies to the container.",
                               "type": "string"
                             },
                             "type": {
+                              "description": "Type is a SELinux type label that applies to the container.",
                               "type": "string"
                             },
                             "user": {
+                              "description": "User is a SELinux user label that applies to the container.",
                               "type": "string"
                             }
                           },
@@ -2092,11 +2890,14 @@
                           "additionalProperties": false
                         },
                         "seccompProfile": {
+                          "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
                           "properties": {
                             "localhostProfile": {
+                              "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
                               "type": "string"
                             },
                             "type": {
+                              "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
                               "type": "string"
                             }
                           },
@@ -2107,17 +2908,22 @@
                           "additionalProperties": false
                         },
                         "windowsOptions": {
+                          "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
                           "properties": {
                             "gmsaCredentialSpec": {
+                              "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
                               "type": "string"
                             },
                             "gmsaCredentialSpecName": {
+                              "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                               "type": "string"
                             },
                             "hostProcess": {
+                              "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
                               "type": "boolean"
                             },
                             "runAsUserName": {
+                              "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
                               "type": "string"
                             }
                           },
@@ -2129,24 +2935,32 @@
                       "additionalProperties": false
                     },
                     "volumeMounts": {
+                      "description": "Specify additional volume mounts in the container.",
                       "items": {
+                        "description": "VolumeMount describes a mounting of a Volume within a container.",
                         "properties": {
                           "mountPath": {
+                            "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
                             "type": "string"
                           },
                           "mountPropagation": {
+                            "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
                             "type": "string"
                           },
                           "name": {
+                            "description": "This must match the Name of a Volume.",
                             "type": "string"
                           },
                           "readOnly": {
+                            "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
                             "type": "boolean"
                           },
                           "subPath": {
+                            "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
                             "type": "string"
                           },
                           "subPathExpr": {
+                            "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
                             "type": "string"
                           }
                         },
@@ -2168,30 +2982,40 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "description": "Configure the basic configurations for each Agent container. Valid Agent container names are: `agent`, `cluster-agent`, `init-config`, `init-volume`, `process-agent`, `seccomp-setup`, `security-agent`, `system-probe`, `trace-agent`, and `all`. Configuration under `all` applies to all configured containers.",
                 "type": "object"
               },
               "createRbac": {
+                "description": "Set CreateRbac to false to prevent automatic creation of Role/ClusterRole for this component",
                 "type": "boolean"
               },
               "customConfigurations": {
                 "additionalProperties": {
+                  "description": "CustomConfig provides a place for custom configuration of the Agent or Cluster Agent, corresponding to datadog.yaml, system-probe.yaml, security-agent.yaml or datadog-cluster.yaml. The configuration can be provided in the ConfigData field as raw data, or referenced in a ConfigMap. Note: `ConfigData` and `ConfigMap` cannot be set together.",
                   "properties": {
                     "configData": {
+                      "description": "ConfigData corresponds to the configuration file content.",
                       "type": "string"
                     },
                     "configMap": {
+                      "description": "ConfigMap references an existing ConfigMap with the configuration file content.",
                       "properties": {
                         "items": {
+                          "description": "Items maps a ConfigMap data `key` to a file `path` mount.",
                           "items": {
+                            "description": "Maps a string key to a path within a volume.",
                             "properties": {
                               "key": {
+                                "description": "key is the key to project.",
                                 "type": "string"
                               },
                               "mode": {
+                                "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                 "format": "int32",
                                 "type": "integer"
                               },
                               "path": {
+                                "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                 "type": "string"
                               }
                             },
@@ -2209,6 +3033,7 @@
                           "x-kubernetes-list-type": "map"
                         },
                         "name": {
+                          "description": "Name is the name of the ConfigMap.",
                           "type": "string"
                         }
                       },
@@ -2219,31 +3044,42 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "description": "CustomConfiguration allows to specify custom configuration files for `datadog.yaml`, `datadog-cluster.yaml`, `security-agent.yaml`, and `system-probe.yaml`. The content is merged with configuration generated by the Datadog Operator, with priority given to custom configuration. WARNING: It is possible to override values set in the `DatadogAgent`.",
                 "type": "object"
               },
               "disabled": {
+                "description": "Disabled force disables a component.",
                 "type": "boolean"
               },
               "env": {
+                "description": "Specify additional environment variables for all containers in this component Priority is Container > Component. See also: https://docs.datadoghq.com/agent/kubernetes/?tab=helm#environment-variables",
                 "items": {
+                  "description": "EnvVar represents an environment variable present in a Container.",
                   "properties": {
                     "name": {
+                      "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                       "type": "string"
                     },
                     "value": {
+                      "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
                       "type": "string"
                     },
                     "valueFrom": {
+                      "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                       "properties": {
                         "configMapKeyRef": {
+                          "description": "Selects a key of a ConfigMap.",
                           "properties": {
                             "key": {
+                              "description": "The key to select.",
                               "type": "string"
                             },
                             "name": {
+                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                               "type": "string"
                             },
                             "optional": {
+                              "description": "Specify whether the ConfigMap or its key must be defined",
                               "type": "boolean"
                             }
                           },
@@ -2254,11 +3090,14 @@
                           "additionalProperties": false
                         },
                         "fieldRef": {
+                          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                           "properties": {
                             "apiVersion": {
+                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                               "type": "string"
                             },
                             "fieldPath": {
+                              "description": "Path of the field to select in the specified API version.",
                               "type": "string"
                             }
                           },
@@ -2269,8 +3108,10 @@
                           "additionalProperties": false
                         },
                         "resourceFieldRef": {
+                          "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                           "properties": {
                             "containerName": {
+                              "description": "Container name: required for volumes, optional for env vars",
                               "type": "string"
                             },
                             "divisor": {
@@ -2282,10 +3123,12 @@
                                   "type": "string"
                                 }
                               ],
+                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                               "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                               "x-kubernetes-int-or-string": true
                             },
                             "resource": {
+                              "description": "Required: resource to select",
                               "type": "string"
                             }
                           },
@@ -2296,14 +3139,18 @@
                           "additionalProperties": false
                         },
                         "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
                           "properties": {
                             "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
                               "type": "string"
                             },
                             "name": {
+                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                               "type": "string"
                             },
                             "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
                               "type": "boolean"
                             }
                           },
@@ -2331,26 +3178,34 @@
                 "x-kubernetes-list-type": "map"
               },
               "extraChecksd": {
+                "description": "Checksd configuration allowing to specify custom checks placed under /etc/datadog-agent/checks.d/ See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.",
                 "properties": {
                   "configDataMap": {
                     "additionalProperties": {
                       "type": "string"
                     },
+                    "description": "ConfigDataMap corresponds to the content of the configuration files. The key should be the filename the contents get mounted to; for instance check.py or check.yaml.",
                     "type": "object"
                   },
                   "configMap": {
+                    "description": "ConfigMap references an existing ConfigMap with the content of the configuration files.",
                     "properties": {
                       "items": {
+                        "description": "Items maps a ConfigMap data `key` to a file `path` mount.",
                         "items": {
+                          "description": "Maps a string key to a path within a volume.",
                           "properties": {
                             "key": {
+                              "description": "key is the key to project.",
                               "type": "string"
                             },
                             "mode": {
+                              "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                               "format": "int32",
                               "type": "integer"
                             },
                             "path": {
+                              "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                               "type": "string"
                             }
                           },
@@ -2368,6 +3223,7 @@
                         "x-kubernetes-list-type": "map"
                       },
                       "name": {
+                        "description": "Name is the name of the ConfigMap.",
                         "type": "string"
                       }
                     },
@@ -2379,26 +3235,34 @@
                 "additionalProperties": false
               },
               "extraConfd": {
+                "description": "Confd configuration allowing to specify config files for custom checks placed under /etc/datadog-agent/conf.d/. See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.",
                 "properties": {
                   "configDataMap": {
                     "additionalProperties": {
                       "type": "string"
                     },
+                    "description": "ConfigDataMap corresponds to the content of the configuration files. The key should be the filename the contents get mounted to; for instance check.py or check.yaml.",
                     "type": "object"
                   },
                   "configMap": {
+                    "description": "ConfigMap references an existing ConfigMap with the content of the configuration files.",
                     "properties": {
                       "items": {
+                        "description": "Items maps a ConfigMap data `key` to a file `path` mount.",
                         "items": {
+                          "description": "Maps a string key to a path within a volume.",
                           "properties": {
                             "key": {
+                              "description": "key is the key to project.",
                               "type": "string"
                             },
                             "mode": {
+                              "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                               "format": "int32",
                               "type": "integer"
                             },
                             "path": {
+                              "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                               "type": "string"
                             }
                           },
@@ -2416,6 +3280,7 @@
                         "x-kubernetes-list-type": "map"
                       },
                       "name": {
+                        "description": "Name is the name of the ConfigMap.",
                         "type": "string"
                       }
                     },
@@ -2427,26 +3292,35 @@
                 "additionalProperties": false
               },
               "hostNetwork": {
+                "description": "Host networking requested for this pod. Use the host's network namespace.",
                 "type": "boolean"
               },
               "hostPID": {
+                "description": "Use the host's PID namespace.",
                 "type": "boolean"
               },
               "image": {
+                "description": "The container image of the different components (Datadog Agent, Cluster Agent, Cluster Check Runner).",
                 "properties": {
                   "jmxEnabled": {
+                    "description": "Define whether the Agent image should support JMX. To be used if the Name field does not correspond to a full image string.",
                     "type": "boolean"
                   },
                   "name": {
+                    "description": "Define the image to use: Use \"gcr.io/datadoghq/agent:latest\" for Datadog Agent 7. Use \"datadog/dogstatsd:latest\" for standalone Datadog Agent DogStatsD 7. Use \"gcr.io/datadoghq/cluster-agent:latest\" for Datadog Cluster Agent. Use \"agent\" with the registry and tag configurations for <registry>/agent:<tag>. Use \"cluster-agent\" with the registry and tag configurations for <registry>/cluster-agent:<tag>. If the name is the full image string\u2014`<name>:<tag>` or `<registry>/<name>:<tag>`, then `tag`, `jmxEnabled`, and `global.registry` values are ignored. Otherwise, image string is created by overriding default settings with supplied `name`, `tag`, and `jmxEnabled` values; image string is created using default registry unless `global.registry` is configured.",
                     "type": "string"
                   },
                   "pullPolicy": {
+                    "description": "The Kubernetes pull policy: Use Always, Never, or IfNotPresent.",
                     "type": "string"
                   },
                   "pullSecrets": {
+                    "description": "It is possible to specify Docker registry credentials. See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
                     "items": {
+                      "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
                       "properties": {
                         "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                           "type": "string"
                         }
                       },
@@ -2456,6 +3330,7 @@
                     "type": "array"
                   },
                   "tag": {
+                    "description": "Define the image tag to use. To be used if the Name field does not correspond to a full image string.",
                     "type": "string"
                   }
                 },
@@ -2466,56 +3341,72 @@
                 "additionalProperties": {
                   "type": "string"
                 },
+                "description": "AdditionalLabels provide labels that are added to the different component (Datadog Agent, Cluster Agent, Cluster Check Runner) pods.",
                 "type": "object"
               },
               "name": {
+                "description": "Name overrides the default name for the resource",
                 "type": "string"
               },
               "nodeSelector": {
                 "additionalProperties": {
                   "type": "string"
                 },
+                "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
                 "type": "object"
               },
               "priorityClassName": {
+                "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority is default, or zero if there is no default.",
                 "type": "string"
               },
               "replicas": {
+                "description": "Number of the replicas. Not applicable for a DaemonSet/ExtendedDaemonSet deployment",
                 "format": "int32",
                 "type": "integer"
               },
               "securityContext": {
+                "description": "Pod-level SecurityContext.",
                 "properties": {
                   "fsGroup": {
+                    "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
                     "format": "int64",
                     "type": "integer"
                   },
                   "fsGroupChangePolicy": {
+                    "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.",
                     "type": "string"
                   },
                   "runAsGroup": {
+                    "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
                     "format": "int64",
                     "type": "integer"
                   },
                   "runAsNonRoot": {
+                    "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
                     "type": "boolean"
                   },
                   "runAsUser": {
+                    "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
                     "format": "int64",
                     "type": "integer"
                   },
                   "seLinuxOptions": {
+                    "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
                     "properties": {
                       "level": {
+                        "description": "Level is SELinux level label that applies to the container.",
                         "type": "string"
                       },
                       "role": {
+                        "description": "Role is a SELinux role label that applies to the container.",
                         "type": "string"
                       },
                       "type": {
+                        "description": "Type is a SELinux type label that applies to the container.",
                         "type": "string"
                       },
                       "user": {
+                        "description": "User is a SELinux user label that applies to the container.",
                         "type": "string"
                       }
                     },
@@ -2523,11 +3414,14 @@
                     "additionalProperties": false
                   },
                   "seccompProfile": {
+                    "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.",
                     "properties": {
                       "localhostProfile": {
+                        "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
                         "type": "string"
                       },
                       "type": {
+                        "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
                         "type": "string"
                       }
                     },
@@ -2538,6 +3432,7 @@
                     "additionalProperties": false
                   },
                   "supplementalGroups": {
+                    "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container. Note that this field cannot be set when spec.os.name is windows.",
                     "items": {
                       "format": "int64",
                       "type": "integer"
@@ -2545,12 +3440,16 @@
                     "type": "array"
                   },
                   "sysctls": {
+                    "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
                     "items": {
+                      "description": "Sysctl defines a kernel parameter to be set",
                       "properties": {
                         "name": {
+                          "description": "Name of a property to set",
                           "type": "string"
                         },
                         "value": {
+                          "description": "Value of a property to set",
                           "type": "string"
                         }
                       },
@@ -2564,238 +3463,25 @@
                     "type": "array"
                   },
                   "windowsOptions": {
+                    "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
                     "properties": {
                       "gmsaCredentialSpec": {
+                        "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
                         "type": "string"
                       },
                       "gmsaCredentialSpecName": {
+                        "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                         "type": "string"
                       },
                       "hostProcess": {
+                        "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
                         "type": "boolean"
                       },
                       "runAsUserName": {
+                        "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "securityContextConstraints": {
-                "properties": {
-                  "create": {
-                    "type": "boolean"
-                  },
-                  "customConfiguration": {
-                    "properties": {
-                      "allowHostDirVolumePlugin": {
-                        "type": "boolean"
-                      },
-                      "allowHostIPC": {
-                        "type": "boolean"
-                      },
-                      "allowHostNetwork": {
-                        "type": "boolean"
-                      },
-                      "allowHostPID": {
-                        "type": "boolean"
-                      },
-                      "allowHostPorts": {
-                        "type": "boolean"
-                      },
-                      "allowPrivilegedContainer": {
-                        "type": "boolean"
-                      },
-                      "allowedCapabilities": {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "allowedFlexVolumes": {
-                        "items": {
-                          "properties": {
-                            "driver": {
-                              "type": "string"
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "type": "array"
-                      },
-                      "apiVersion": {
-                        "type": "string"
-                      },
-                      "defaultAddCapabilities": {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "fsGroup": {
-                        "properties": {
-                          "ranges": {
-                            "items": {
-                              "properties": {
-                                "max": {
-                                  "format": "int64",
-                                  "type": "integer"
-                                },
-                                "min": {
-                                  "format": "int64",
-                                  "type": "integer"
-                                }
-                              },
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array"
-                          },
-                          "type": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "groups": {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "kind": {
-                        "type": "string"
-                      },
-                      "metadata": {
-                        "type": "object"
-                      },
-                      "priority": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "readOnlyRootFilesystem": {
-                        "type": "boolean"
-                      },
-                      "requiredDropCapabilities": {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "runAsUser": {
-                        "properties": {
-                          "type": {
-                            "type": "string"
-                          },
-                          "uid": {
-                            "format": "int64",
-                            "type": "integer"
-                          },
-                          "uidRangeMax": {
-                            "format": "int64",
-                            "type": "integer"
-                          },
-                          "uidRangeMin": {
-                            "format": "int64",
-                            "type": "integer"
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "seLinuxContext": {
-                        "properties": {
-                          "seLinuxOptions": {
-                            "properties": {
-                              "level": {
-                                "type": "string"
-                              },
-                              "role": {
-                                "type": "string"
-                              },
-                              "type": {
-                                "type": "string"
-                              },
-                              "user": {
-                                "type": "string"
-                              }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "type": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "seccompProfiles": {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "supplementalGroups": {
-                        "properties": {
-                          "ranges": {
-                            "items": {
-                              "properties": {
-                                "max": {
-                                  "format": "int64",
-                                  "type": "integer"
-                                },
-                                "min": {
-                                  "format": "int64",
-                                  "type": "integer"
-                                }
-                              },
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array"
-                          },
-                          "type": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "users": {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "volumes": {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      }
-                    },
-                    "required": [
-                      "allowHostDirVolumePlugin",
-                      "allowHostIPC",
-                      "allowHostNetwork",
-                      "allowHostPID",
-                      "allowHostPorts",
-                      "allowPrivilegedContainer",
-                      "allowedCapabilities",
-                      "allowedFlexVolumes",
-                      "defaultAddCapabilities",
-                      "priority",
-                      "readOnlyRootFilesystem",
-                      "requiredDropCapabilities",
-                      "volumes"
-                    ],
                     "type": "object",
                     "additionalProperties": false
                   }
@@ -2804,25 +3490,33 @@
                 "additionalProperties": false
               },
               "serviceAccountName": {
+                "description": "Sets the ServiceAccount used by this component. Ignored if the field CreateRbac is true.",
                 "type": "string"
               },
               "tolerations": {
+                "description": "Configure the component tolerations.",
                 "items": {
+                  "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
                   "properties": {
                     "effect": {
+                      "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                       "type": "string"
                     },
                     "key": {
+                      "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                       "type": "string"
                     },
                     "operator": {
+                      "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
                       "type": "string"
                     },
                     "tolerationSeconds": {
+                      "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "value": {
+                      "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
                       "type": "string"
                     }
                   },
@@ -2833,21 +3527,28 @@
                 "x-kubernetes-list-type": "atomic"
               },
               "volumes": {
+                "description": "Specify additional volumes in the different components (Datadog Agent, Cluster Agent, Cluster Check Runner).",
                 "items": {
+                  "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
                   "properties": {
                     "awsElasticBlockStore": {
+                      "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                       "properties": {
                         "fsType": {
+                          "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine",
                           "type": "string"
                         },
                         "partition": {
+                          "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
                           "format": "int32",
                           "type": "integer"
                         },
                         "readOnly": {
+                          "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                           "type": "boolean"
                         },
                         "volumeID": {
+                          "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                           "type": "string"
                         }
                       },
@@ -2858,23 +3559,30 @@
                       "additionalProperties": false
                     },
                     "azureDisk": {
+                      "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
                       "properties": {
                         "cachingMode": {
+                          "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
                           "type": "string"
                         },
                         "diskName": {
+                          "description": "diskName is the Name of the data disk in the blob storage",
                           "type": "string"
                         },
                         "diskURI": {
+                          "description": "diskURI is the URI of data disk in the blob storage",
                           "type": "string"
                         },
                         "fsType": {
+                          "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                           "type": "string"
                         },
                         "kind": {
+                          "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
                           "type": "string"
                         },
                         "readOnly": {
+                          "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                           "type": "boolean"
                         }
                       },
@@ -2886,14 +3594,18 @@
                       "additionalProperties": false
                     },
                     "azureFile": {
+                      "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.",
                       "properties": {
                         "readOnly": {
+                          "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                           "type": "boolean"
                         },
                         "secretName": {
+                          "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
                           "type": "string"
                         },
                         "shareName": {
+                          "description": "shareName is the azure share Name",
                           "type": "string"
                         }
                       },
@@ -2905,25 +3617,32 @@
                       "additionalProperties": false
                     },
                     "cephfs": {
+                      "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
                       "properties": {
                         "monitors": {
+                          "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                           "items": {
                             "type": "string"
                           },
                           "type": "array"
                         },
                         "path": {
+                          "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
                           "type": "string"
                         },
                         "readOnly": {
+                          "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                           "type": "boolean"
                         },
                         "secretFile": {
+                          "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                           "type": "string"
                         },
                         "secretRef": {
+                          "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                           "properties": {
                             "name": {
+                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                               "type": "string"
                             }
                           },
@@ -2931,6 +3650,7 @@
                           "additionalProperties": false
                         },
                         "user": {
+                          "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                           "type": "string"
                         }
                       },
@@ -2941,16 +3661,21 @@
                       "additionalProperties": false
                     },
                     "cinder": {
+                      "description": "cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                       "properties": {
                         "fsType": {
+                          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                           "type": "string"
                         },
                         "readOnly": {
+                          "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                           "type": "boolean"
                         },
                         "secretRef": {
+                          "description": "secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.",
                           "properties": {
                             "name": {
+                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                               "type": "string"
                             }
                           },
@@ -2958,6 +3683,7 @@
                           "additionalProperties": false
                         },
                         "volumeID": {
+                          "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                           "type": "string"
                         }
                       },
@@ -2968,22 +3694,29 @@
                       "additionalProperties": false
                     },
                     "configMap": {
+                      "description": "configMap represents a configMap that should populate this volume",
                       "properties": {
                         "defaultMode": {
+                          "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "items": {
+                          "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                           "items": {
+                            "description": "Maps a string key to a path within a volume.",
                             "properties": {
                               "key": {
+                                "description": "key is the key to project.",
                                 "type": "string"
                               },
                               "mode": {
+                                "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                 "format": "int32",
                                 "type": "integer"
                               },
                               "path": {
+                                "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                 "type": "string"
                               }
                             },
@@ -2997,9 +3730,11 @@
                           "type": "array"
                         },
                         "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                           "type": "string"
                         },
                         "optional": {
+                          "description": "optional specify whether the ConfigMap or its keys must be defined",
                           "type": "boolean"
                         }
                       },
@@ -3007,16 +3742,21 @@
                       "additionalProperties": false
                     },
                     "csi": {
+                      "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
                       "properties": {
                         "driver": {
+                          "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
                           "type": "string"
                         },
                         "fsType": {
+                          "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
                           "type": "string"
                         },
                         "nodePublishSecretRef": {
+                          "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
                           "properties": {
                             "name": {
+                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                               "type": "string"
                             }
                           },
@@ -3024,12 +3764,14 @@
                           "additionalProperties": false
                         },
                         "readOnly": {
+                          "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
                           "type": "boolean"
                         },
                         "volumeAttributes": {
                           "additionalProperties": {
                             "type": "string"
                           },
+                          "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
                           "type": "object"
                         }
                       },
@@ -3040,20 +3782,27 @@
                       "additionalProperties": false
                     },
                     "downwardAPI": {
+                      "description": "downwardAPI represents downward API about the pod that should populate this volume",
                       "properties": {
                         "defaultMode": {
+                          "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "items": {
+                          "description": "Items is a list of downward API volume file",
                           "items": {
+                            "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
                             "properties": {
                               "fieldRef": {
+                                "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
                                 "properties": {
                                   "apiVersion": {
+                                    "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                     "type": "string"
                                   },
                                   "fieldPath": {
+                                    "description": "Path of the field to select in the specified API version.",
                                     "type": "string"
                                   }
                                 },
@@ -3064,15 +3813,19 @@
                                 "additionalProperties": false
                               },
                               "mode": {
+                                "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                 "format": "int32",
                                 "type": "integer"
                               },
                               "path": {
+                                "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
                                 "type": "string"
                               },
                               "resourceFieldRef": {
+                                "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
                                 "properties": {
                                   "containerName": {
+                                    "description": "Container name: required for volumes, optional for env vars",
                                     "type": "string"
                                   },
                                   "divisor": {
@@ -3084,10 +3837,12 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                     "x-kubernetes-int-or-string": true
                                   },
                                   "resource": {
+                                    "description": "Required: resource to select",
                                     "type": "string"
                                   }
                                 },
@@ -3111,8 +3866,10 @@
                       "additionalProperties": false
                     },
                     "emptyDir": {
+                      "description": "emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                       "properties": {
                         "medium": {
+                          "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                           "type": "string"
                         },
                         "sizeLimit": {
@@ -3124,6 +3881,7 @@
                               "type": "string"
                             }
                           ],
+                          "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                           "x-kubernetes-int-or-string": true
                         }
@@ -3132,29 +3890,38 @@
                       "additionalProperties": false
                     },
                     "ephemeral": {
+                      "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
                       "properties": {
                         "volumeClaimTemplate": {
+                          "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil.",
                           "properties": {
                             "metadata": {
+                              "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
                               "type": "object"
                             },
                             "spec": {
+                              "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
                               "properties": {
                                 "accessModes": {
+                                  "description": "accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
                                   "items": {
                                     "type": "string"
                                   },
                                   "type": "array"
                                 },
                                 "dataSource": {
+                                  "description": "dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.",
                                   "properties": {
                                     "apiGroup": {
+                                      "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
                                       "type": "string"
                                     },
                                     "kind": {
+                                      "description": "Kind is the type of resource being referenced",
                                       "type": "string"
                                     },
                                     "name": {
+                                      "description": "Name is the name of resource being referenced",
                                       "type": "string"
                                     }
                                   },
@@ -3166,14 +3933,18 @@
                                   "additionalProperties": false
                                 },
                                 "dataSourceRef": {
+                                  "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.",
                                   "properties": {
                                     "apiGroup": {
+                                      "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
                                       "type": "string"
                                     },
                                     "kind": {
+                                      "description": "Kind is the type of resource being referenced",
                                       "type": "string"
                                     },
                                     "name": {
+                                      "description": "Name is the name of resource being referenced",
                                       "type": "string"
                                     }
                                   },
@@ -3185,6 +3956,7 @@
                                   "additionalProperties": false
                                 },
                                 "resources": {
+                                  "description": "resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
                                   "properties": {
                                     "limits": {
                                       "additionalProperties": {
@@ -3199,6 +3971,7 @@
                                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                         "x-kubernetes-int-or-string": true
                                       },
+                                      "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                                       "type": "object"
                                     },
                                     "requests": {
@@ -3214,6 +3987,7 @@
                                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                         "x-kubernetes-int-or-string": true
                                       },
+                                      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                                       "type": "object"
                                     }
                                   },
@@ -3221,17 +3995,23 @@
                                   "additionalProperties": false
                                 },
                                 "selector": {
+                                  "description": "selector is a label query over volumes to consider for binding.",
                                   "properties": {
                                     "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                       "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
                                         "properties": {
                                           "key": {
+                                            "description": "key is the label key that the selector applies to.",
                                             "type": "string"
                                           },
                                           "operator": {
+                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
                                             "type": "string"
                                           },
                                           "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -3251,6 +4031,7 @@
                                       "additionalProperties": {
                                         "type": "string"
                                       },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                       "type": "object"
                                     }
                                   },
@@ -3258,12 +4039,15 @@
                                   "additionalProperties": false
                                 },
                                 "storageClassName": {
+                                  "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
                                   "type": "string"
                                 },
                                 "volumeMode": {
+                                  "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
                                   "type": "string"
                                 },
                                 "volumeName": {
+                                  "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
                                   "type": "string"
                                 }
                               },
@@ -3282,24 +4066,30 @@
                       "additionalProperties": false
                     },
                     "fc": {
+                      "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
                       "properties": {
                         "fsType": {
+                          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine",
                           "type": "string"
                         },
                         "lun": {
+                          "description": "lun is Optional: FC target lun number",
                           "format": "int32",
                           "type": "integer"
                         },
                         "readOnly": {
+                          "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                           "type": "boolean"
                         },
                         "targetWWNs": {
+                          "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
                           "items": {
                             "type": "string"
                           },
                           "type": "array"
                         },
                         "wwids": {
+                          "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
                           "items": {
                             "type": "string"
                           },
@@ -3310,25 +4100,32 @@
                       "additionalProperties": false
                     },
                     "flexVolume": {
+                      "description": "flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
                       "properties": {
                         "driver": {
+                          "description": "driver is the name of the driver to use for this volume.",
                           "type": "string"
                         },
                         "fsType": {
+                          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
                           "type": "string"
                         },
                         "options": {
                           "additionalProperties": {
                             "type": "string"
                           },
+                          "description": "options is Optional: this field holds extra command options if any.",
                           "type": "object"
                         },
                         "readOnly": {
+                          "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                           "type": "boolean"
                         },
                         "secretRef": {
+                          "description": "secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
                           "properties": {
                             "name": {
+                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                               "type": "string"
                             }
                           },
@@ -3343,11 +4140,14 @@
                       "additionalProperties": false
                     },
                     "flocker": {
+                      "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
                       "properties": {
                         "datasetName": {
+                          "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
                           "type": "string"
                         },
                         "datasetUUID": {
+                          "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
                           "type": "string"
                         }
                       },
@@ -3355,18 +4155,23 @@
                       "additionalProperties": false
                     },
                     "gcePersistentDisk": {
+                      "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                       "properties": {
                         "fsType": {
+                          "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine",
                           "type": "string"
                         },
                         "partition": {
+                          "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                           "format": "int32",
                           "type": "integer"
                         },
                         "pdName": {
+                          "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                           "type": "string"
                         },
                         "readOnly": {
+                          "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                           "type": "boolean"
                         }
                       },
@@ -3377,14 +4182,18 @@
                       "additionalProperties": false
                     },
                     "gitRepo": {
+                      "description": "gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
                       "properties": {
                         "directory": {
+                          "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
                           "type": "string"
                         },
                         "repository": {
+                          "description": "repository is the URL",
                           "type": "string"
                         },
                         "revision": {
+                          "description": "revision is the commit hash for the specified revision.",
                           "type": "string"
                         }
                       },
@@ -3395,14 +4204,18 @@
                       "additionalProperties": false
                     },
                     "glusterfs": {
+                      "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md",
                       "properties": {
                         "endpoints": {
+                          "description": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                           "type": "string"
                         },
                         "path": {
+                          "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                           "type": "string"
                         },
                         "readOnly": {
+                          "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                           "type": "boolean"
                         }
                       },
@@ -3414,11 +4227,14 @@
                       "additionalProperties": false
                     },
                     "hostPath": {
+                      "description": "hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
                       "properties": {
                         "path": {
+                          "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                           "type": "string"
                         },
                         "type": {
+                          "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                           "type": "string"
                         }
                       },
@@ -3429,41 +4245,53 @@
                       "additionalProperties": false
                     },
                     "iscsi": {
+                      "description": "iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
                       "properties": {
                         "chapAuthDiscovery": {
+                          "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
                           "type": "boolean"
                         },
                         "chapAuthSession": {
+                          "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
                           "type": "boolean"
                         },
                         "fsType": {
+                          "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine",
                           "type": "string"
                         },
                         "initiatorName": {
+                          "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
                           "type": "string"
                         },
                         "iqn": {
+                          "description": "iqn is the target iSCSI Qualified Name.",
                           "type": "string"
                         },
                         "iscsiInterface": {
+                          "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
                           "type": "string"
                         },
                         "lun": {
+                          "description": "lun represents iSCSI Target Lun number.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "portals": {
+                          "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
                           "items": {
                             "type": "string"
                           },
                           "type": "array"
                         },
                         "readOnly": {
+                          "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
                           "type": "boolean"
                         },
                         "secretRef": {
+                          "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
                           "properties": {
                             "name": {
+                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                               "type": "string"
                             }
                           },
@@ -3471,6 +4299,7 @@
                           "additionalProperties": false
                         },
                         "targetPortal": {
+                          "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
                           "type": "string"
                         }
                       },
@@ -3483,17 +4312,22 @@
                       "additionalProperties": false
                     },
                     "name": {
+                      "description": "name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "nfs": {
+                      "description": "nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                       "properties": {
                         "path": {
+                          "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                           "type": "string"
                         },
                         "readOnly": {
+                          "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                           "type": "boolean"
                         },
                         "server": {
+                          "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                           "type": "string"
                         }
                       },
@@ -3505,11 +4339,14 @@
                       "additionalProperties": false
                     },
                     "persistentVolumeClaim": {
+                      "description": "persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                       "properties": {
                         "claimName": {
+                          "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                           "type": "string"
                         },
                         "readOnly": {
+                          "description": "readOnly Will force the ReadOnly setting in VolumeMounts. Default false.",
                           "type": "boolean"
                         }
                       },
@@ -3520,11 +4357,14 @@
                       "additionalProperties": false
                     },
                     "photonPersistentDisk": {
+                      "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
                       "properties": {
                         "fsType": {
+                          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                           "type": "string"
                         },
                         "pdID": {
+                          "description": "pdID is the ID that identifies Photon Controller persistent disk",
                           "type": "string"
                         }
                       },
@@ -3535,14 +4375,18 @@
                       "additionalProperties": false
                     },
                     "portworxVolume": {
+                      "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine",
                       "properties": {
                         "fsType": {
+                          "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                           "type": "string"
                         },
                         "readOnly": {
+                          "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                           "type": "boolean"
                         },
                         "volumeID": {
+                          "description": "volumeID uniquely identifies a Portworx volume",
                           "type": "string"
                         }
                       },
@@ -3553,27 +4397,37 @@
                       "additionalProperties": false
                     },
                     "projected": {
+                      "description": "projected items for all in one resources secrets, configmaps, and downward API",
                       "properties": {
                         "defaultMode": {
+                          "description": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "sources": {
+                          "description": "sources is the list of volume projections",
                           "items": {
+                            "description": "Projection that may be projected along with other supported volume types",
                             "properties": {
                               "configMap": {
+                                "description": "configMap information about the configMap data to project",
                                 "properties": {
                                   "items": {
+                                    "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                                     "items": {
+                                      "description": "Maps a string key to a path within a volume.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the key to project.",
                                           "type": "string"
                                         },
                                         "mode": {
+                                          "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                           "format": "int32",
                                           "type": "integer"
                                         },
                                         "path": {
+                                          "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                           "type": "string"
                                         }
                                       },
@@ -3587,9 +4441,11 @@
                                     "type": "array"
                                   },
                                   "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                     "type": "string"
                                   },
                                   "optional": {
+                                    "description": "optional specify whether the ConfigMap or its keys must be defined",
                                     "type": "boolean"
                                   }
                                 },
@@ -3597,16 +4453,22 @@
                                 "additionalProperties": false
                               },
                               "downwardAPI": {
+                                "description": "downwardAPI information about the downwardAPI data to project",
                                 "properties": {
                                   "items": {
+                                    "description": "Items is a list of DownwardAPIVolume file",
                                     "items": {
+                                      "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
                                       "properties": {
                                         "fieldRef": {
+                                          "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
                                           "properties": {
                                             "apiVersion": {
+                                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                               "type": "string"
                                             },
                                             "fieldPath": {
+                                              "description": "Path of the field to select in the specified API version.",
                                               "type": "string"
                                             }
                                           },
@@ -3617,15 +4479,19 @@
                                           "additionalProperties": false
                                         },
                                         "mode": {
+                                          "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                           "format": "int32",
                                           "type": "integer"
                                         },
                                         "path": {
+                                          "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
                                           "type": "string"
                                         },
                                         "resourceFieldRef": {
+                                          "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
                                           "properties": {
                                             "containerName": {
+                                              "description": "Container name: required for volumes, optional for env vars",
                                               "type": "string"
                                             },
                                             "divisor": {
@@ -3637,10 +4503,12 @@
                                                   "type": "string"
                                                 }
                                               ],
+                                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                               "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                               "x-kubernetes-int-or-string": true
                                             },
                                             "resource": {
+                                              "description": "Required: resource to select",
                                               "type": "string"
                                             }
                                           },
@@ -3664,18 +4532,24 @@
                                 "additionalProperties": false
                               },
                               "secret": {
+                                "description": "secret information about the secret data to project",
                                 "properties": {
                                   "items": {
+                                    "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                                     "items": {
+                                      "description": "Maps a string key to a path within a volume.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the key to project.",
                                           "type": "string"
                                         },
                                         "mode": {
+                                          "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                           "format": "int32",
                                           "type": "integer"
                                         },
                                         "path": {
+                                          "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                           "type": "string"
                                         }
                                       },
@@ -3689,9 +4563,11 @@
                                     "type": "array"
                                   },
                                   "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                     "type": "string"
                                   },
                                   "optional": {
+                                    "description": "optional field specify whether the Secret or its key must be defined",
                                     "type": "boolean"
                                   }
                                 },
@@ -3699,15 +4575,19 @@
                                 "additionalProperties": false
                               },
                               "serviceAccountToken": {
+                                "description": "serviceAccountToken is information about the serviceAccountToken data to project",
                                 "properties": {
                                   "audience": {
+                                    "description": "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
                                     "type": "string"
                                   },
                                   "expirationSeconds": {
+                                    "description": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
                                     "format": "int64",
                                     "type": "integer"
                                   },
                                   "path": {
+                                    "description": "path is the path relative to the mount point of the file to project the token into.",
                                     "type": "string"
                                   }
                                 },
@@ -3728,23 +4608,30 @@
                       "additionalProperties": false
                     },
                     "quobyte": {
+                      "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
                       "properties": {
                         "group": {
+                          "description": "group to map volume access to Default is no group",
                           "type": "string"
                         },
                         "readOnly": {
+                          "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
                           "type": "boolean"
                         },
                         "registry": {
+                          "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
                           "type": "string"
                         },
                         "tenant": {
+                          "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
                           "type": "string"
                         },
                         "user": {
+                          "description": "user to map volume access to Defaults to serivceaccount user",
                           "type": "string"
                         },
                         "volume": {
+                          "description": "volume is a string that references an already created Quobyte volume by name.",
                           "type": "string"
                         }
                       },
@@ -3756,31 +4643,40 @@
                       "additionalProperties": false
                     },
                     "rbd": {
+                      "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md",
                       "properties": {
                         "fsType": {
+                          "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine",
                           "type": "string"
                         },
                         "image": {
+                          "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                           "type": "string"
                         },
                         "keyring": {
+                          "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                           "type": "string"
                         },
                         "monitors": {
+                          "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                           "items": {
                             "type": "string"
                           },
                           "type": "array"
                         },
                         "pool": {
+                          "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                           "type": "string"
                         },
                         "readOnly": {
+                          "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                           "type": "boolean"
                         },
                         "secretRef": {
+                          "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                           "properties": {
                             "name": {
+                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                               "type": "string"
                             }
                           },
@@ -3788,6 +4684,7 @@
                           "additionalProperties": false
                         },
                         "user": {
+                          "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                           "type": "string"
                         }
                       },
@@ -3799,22 +4696,29 @@
                       "additionalProperties": false
                     },
                     "scaleIO": {
+                      "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
                       "properties": {
                         "fsType": {
+                          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
                           "type": "string"
                         },
                         "gateway": {
+                          "description": "gateway is the host address of the ScaleIO API Gateway.",
                           "type": "string"
                         },
                         "protectionDomain": {
+                          "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
                           "type": "string"
                         },
                         "readOnly": {
+                          "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                           "type": "boolean"
                         },
                         "secretRef": {
+                          "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
                           "properties": {
                             "name": {
+                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                               "type": "string"
                             }
                           },
@@ -3822,18 +4726,23 @@
                           "additionalProperties": false
                         },
                         "sslEnabled": {
+                          "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
                           "type": "boolean"
                         },
                         "storageMode": {
+                          "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
                           "type": "string"
                         },
                         "storagePool": {
+                          "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
                           "type": "string"
                         },
                         "system": {
+                          "description": "system is the name of the storage system as configured in ScaleIO.",
                           "type": "string"
                         },
                         "volumeName": {
+                          "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
                           "type": "string"
                         }
                       },
@@ -3846,22 +4755,29 @@
                       "additionalProperties": false
                     },
                     "secret": {
+                      "description": "secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
                       "properties": {
                         "defaultMode": {
+                          "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "items": {
+                          "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                           "items": {
+                            "description": "Maps a string key to a path within a volume.",
                             "properties": {
                               "key": {
+                                "description": "key is the key to project.",
                                 "type": "string"
                               },
                               "mode": {
+                                "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                 "format": "int32",
                                 "type": "integer"
                               },
                               "path": {
+                                "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                 "type": "string"
                               }
                             },
@@ -3875,9 +4791,11 @@
                           "type": "array"
                         },
                         "optional": {
+                          "description": "optional field specify whether the Secret or its keys must be defined",
                           "type": "boolean"
                         },
                         "secretName": {
+                          "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
                           "type": "string"
                         }
                       },
@@ -3885,16 +4803,21 @@
                       "additionalProperties": false
                     },
                     "storageos": {
+                      "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
                       "properties": {
                         "fsType": {
+                          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                           "type": "string"
                         },
                         "readOnly": {
+                          "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                           "type": "boolean"
                         },
                         "secretRef": {
+                          "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
                           "properties": {
                             "name": {
+                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                               "type": "string"
                             }
                           },
@@ -3902,9 +4825,11 @@
                           "additionalProperties": false
                         },
                         "volumeName": {
+                          "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
                           "type": "string"
                         },
                         "volumeNamespace": {
+                          "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
                           "type": "string"
                         }
                       },
@@ -3912,17 +4837,22 @@
                       "additionalProperties": false
                     },
                     "vsphereVolume": {
+                      "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
                       "properties": {
                         "fsType": {
+                          "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                           "type": "string"
                         },
                         "storagePolicyID": {
+                          "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
                           "type": "string"
                         },
                         "storagePolicyName": {
+                          "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
                           "type": "string"
                         },
                         "volumePath": {
+                          "description": "volumePath is the path that identifies vSphere volume vmdk",
                           "type": "string"
                         }
                       },
@@ -3949,6 +4879,7 @@
             "type": "object",
             "additionalProperties": false
           },
+          "description": "Override the default configurations of the agents",
           "type": "object"
         }
       },
@@ -3956,42 +4887,54 @@
       "additionalProperties": false
     },
     "status": {
+      "description": "DatadogAgentStatus defines the observed state of DatadogAgent.",
       "properties": {
         "agent": {
+          "description": "The combined actual state of all Agents as daemonsets or extended daemonsets.",
           "properties": {
             "available": {
+              "description": "Number of available pods in the DaemonSet.",
               "format": "int32",
               "type": "integer"
             },
             "current": {
+              "description": "Number of current pods in the DaemonSet.",
               "format": "int32",
               "type": "integer"
             },
             "currentHash": {
+              "description": "CurrentHash is the stored hash of the DaemonSet.",
               "type": "string"
             },
             "daemonsetName": {
+              "description": "DaemonsetName corresponds to the name of the created DaemonSet.",
               "type": "string"
             },
             "desired": {
+              "description": "Number of desired pods in the DaemonSet.",
               "format": "int32",
               "type": "integer"
             },
             "lastUpdate": {
+              "description": "LastUpdate is the last time the status was updated.",
               "format": "date-time",
               "type": "string"
             },
             "ready": {
+              "description": "Number of ready pods in the DaemonSet.",
               "format": "int32",
               "type": "integer"
             },
             "state": {
+              "description": "State corresponds to the DaemonSet state.",
               "type": "string"
             },
             "status": {
+              "description": "Status corresponds to the DaemonSet computed status.",
               "type": "string"
             },
             "upToDate": {
+              "description": "Number of up to date pods in the DaemonSet.",
               "format": "int32",
               "type": "integer"
             }
@@ -4006,44 +4949,121 @@
           "type": "object",
           "additionalProperties": false
         },
+        "agentList": {
+          "description": "The actual state of the Agent as a daemonset or an extended daemonset.",
+          "items": {
+            "description": "DaemonSetStatus defines the observed state of Agent running as DaemonSet.",
+            "properties": {
+              "available": {
+                "description": "Number of available pods in the DaemonSet.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "current": {
+                "description": "Number of current pods in the DaemonSet.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "currentHash": {
+                "description": "CurrentHash is the stored hash of the DaemonSet.",
+                "type": "string"
+              },
+              "daemonsetName": {
+                "description": "DaemonsetName corresponds to the name of the created DaemonSet.",
+                "type": "string"
+              },
+              "desired": {
+                "description": "Number of desired pods in the DaemonSet.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "lastUpdate": {
+                "description": "LastUpdate is the last time the status was updated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "ready": {
+                "description": "Number of ready pods in the DaemonSet.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "state": {
+                "description": "State corresponds to the DaemonSet state.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status corresponds to the DaemonSet computed status.",
+                "type": "string"
+              },
+              "upToDate": {
+                "description": "Number of up to date pods in the DaemonSet.",
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "available",
+              "current",
+              "desired",
+              "ready",
+              "upToDate"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
         "clusterAgent": {
+          "description": "The actual state of the Cluster Agent as a deployment.",
           "properties": {
             "availableReplicas": {
+              "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this Deployment.",
               "format": "int32",
               "type": "integer"
             },
             "currentHash": {
+              "description": "CurrentHash is the stored hash of the Deployment.",
               "type": "string"
             },
             "deploymentName": {
+              "description": "DeploymentName corresponds to the name of the Deployment.",
               "type": "string"
             },
             "generatedToken": {
+              "description": "GeneratedToken corresponds to the generated token if any token was provided in the Credential configuration when ClusterAgent is enabled.",
               "type": "string"
             },
             "lastUpdate": {
+              "description": "LastUpdate is the last time the status was updated.",
               "format": "date-time",
               "type": "string"
             },
             "readyReplicas": {
+              "description": "Total number of ready pods targeted by this Deployment.",
               "format": "int32",
               "type": "integer"
             },
             "replicas": {
+              "description": "Total number of non-terminated pods targeted by this Deployment (their labels match the selector).",
               "format": "int32",
               "type": "integer"
             },
             "state": {
+              "description": "State corresponds to the Deployment state.",
               "type": "string"
             },
             "status": {
+              "description": "Status corresponds to the Deployment computed status.",
               "type": "string"
             },
             "unavailableReplicas": {
+              "description": "Total number of unavailable pods targeted by this Deployment. This is the total number of pods that are still required for the Deployment to have 100% available capacity. They may either be pods that are running but not yet available or pods that still have not been created.",
               "format": "int32",
               "type": "integer"
             },
             "updatedReplicas": {
+              "description": "Total number of non-terminated pods targeted by this Deployment that have the desired template spec.",
               "format": "int32",
               "type": "integer"
             }
@@ -4052,43 +5072,55 @@
           "additionalProperties": false
         },
         "clusterChecksRunner": {
+          "description": "The actual state of the Cluster Checks Runner as a deployment.",
           "properties": {
             "availableReplicas": {
+              "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this Deployment.",
               "format": "int32",
               "type": "integer"
             },
             "currentHash": {
+              "description": "CurrentHash is the stored hash of the Deployment.",
               "type": "string"
             },
             "deploymentName": {
+              "description": "DeploymentName corresponds to the name of the Deployment.",
               "type": "string"
             },
             "generatedToken": {
+              "description": "GeneratedToken corresponds to the generated token if any token was provided in the Credential configuration when ClusterAgent is enabled.",
               "type": "string"
             },
             "lastUpdate": {
+              "description": "LastUpdate is the last time the status was updated.",
               "format": "date-time",
               "type": "string"
             },
             "readyReplicas": {
+              "description": "Total number of ready pods targeted by this Deployment.",
               "format": "int32",
               "type": "integer"
             },
             "replicas": {
+              "description": "Total number of non-terminated pods targeted by this Deployment (their labels match the selector).",
               "format": "int32",
               "type": "integer"
             },
             "state": {
+              "description": "State corresponds to the Deployment state.",
               "type": "string"
             },
             "status": {
+              "description": "Status corresponds to the Deployment computed status.",
               "type": "string"
             },
             "unavailableReplicas": {
+              "description": "Total number of unavailable pods targeted by this Deployment. This is the total number of pods that are still required for the Deployment to have 100% available capacity. They may either be pods that are running but not yet available or pods that still have not been created.",
               "format": "int32",
               "type": "integer"
             },
             "updatedReplicas": {
+              "description": "Total number of non-terminated pods targeted by this Deployment that have the desired template spec.",
               "format": "int32",
               "type": "integer"
             }
@@ -4097,28 +5129,35 @@
           "additionalProperties": false
         },
         "conditions": {
+          "description": "Conditions Represents the latest available observations of a DatadogAgent's current state.",
           "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }",
             "properties": {
               "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
+                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
                 "type": "string"
               },
               "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
                 "enum": [
                   "True",
                   "False",
@@ -4127,6 +5166,7 @@
                 "type": "string"
               },
               "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"


### PR DESCRIPTION
Similar to https://github.com/datreeio/CRDs-catalog/pull/179, datadog agent CRDs are outdated.

Based on https://github.com/DataDog/datadog-operator/blob/v1.5.0/bundle/manifests/datadoghq.com_datadogagents.yaml