### PR TITLE
chore(repo management): Updating CI and adding a GitIgnore

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - CODEOWNERS
+      - LICENSE
+      - .gitignore
+      - README.md
+      - .krew.yaml
+      - index.yaml
 
 jobs:
   kubeconform-test:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.idea
+.vscode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix


### PR DESCRIPTION
### Description

This PR updates the CI action so it will ignore files in the repo that aren't JSON files. Doing so will reduce random builds (and save build minutes, but I think they're free for public repos?)

Also (selfish reason) adds a GitIgnore so contributors don't land up adding in guff
